### PR TITLE
refractor(templates/admin): change test environments to have more obvious headers

### DIFF
--- a/EquiTrack/assets/css/main.css
+++ b/EquiTrack/assets/css/main.css
@@ -76,11 +76,10 @@ img {
 }
 #header .brand {
   float: left;
-  width: 280px;
+  width: auto;
   min-height: 60px;
   padding: 0 0 0 10px;
   position: relative;
-  background: #0099ff;
 }
 
 #header .logo {
@@ -89,6 +88,11 @@ img {
   text-transform: uppercase;
   padding: 12px 0 0 25px;
   display: inline-block;
+}
+
+#header .logo #test-text {
+  display: none;
+  color: #e6e600;
 }
 
 #header .logoimg {

--- a/EquiTrack/requirements/base.txt
+++ b/EquiTrack/requirements/base.txt
@@ -49,7 +49,8 @@ django-analytical==2.0.0
 xlrd==0.9.3
 dj-static==0.0.6
 django-easy-pdf
-xhtml2pdf
+xhtml2pdf==0.0.6
+html5lib==0.9999999 #must be added after xhtml2pdf
 reportlab
 
 # testing libs

--- a/EquiTrack/templates/admin/base_site.html
+++ b/EquiTrack/templates/admin/base_site.html
@@ -19,18 +19,18 @@
 
     .header #branding {
         border-right: 0px;
-        width: 280px;
+        width: auto;
+        white-space: nowrap;
     }
 
     .header #branding a {
         text-decoration: none;
-        font-weight: 600;
+        font-weight: 700;
     }
 
     .header #branding h1 {
         text-shadow: none;
-        white-space: nowrap;
-        width:auto;
+        width: 300px;
     }
    .header a:link, a:visited {
         text-decoration: none;
@@ -60,8 +60,9 @@
     }
 
     #header .logo #test-text {
-        display:none;
-        color:#e6e600;
+        display: none;
+        color: #e6e600;
+        font-weight: 700;
     }
 
     .header #user-tools, #country-select {
@@ -149,7 +150,7 @@
          var cond = /localhost|etools-dev|etools-staging/g;
         if (cond.test(window.location)) {
             $('#header').css({'background': '#BE1A1A'});
-            $('#test-text').show().text(" " + host[window.location.hostname]);
+            $('#test-text').show().text(' ' + host[window.location.hostname]);
         }
     });
 
@@ -162,7 +163,7 @@
 
 
     <section id="container">
-    <div id="site-name"><img class="logoimg" src="{{ STATIC_URL }}img/UNICEF_logo_white.png" width="100" style="padding-right: 30px" ><a href="{% url 'admin:index' %}" class="logo">e<span>Tools<span id="test-text"></span></span></a></div>
+    <div id="site-name"><img class="logoimg" src="{{ STATIC_URL }}img/UNICEF_logo_white.png" width="100" style="padding-right: 30px" ><a href="{% url 'admin:index' %}" class="logo">e<span>Tools<span id="test-text">Testing Environment</span></span></a></div>
 {% endblock %}
 {% block usertools %}
         {% if has_permission %}

--- a/EquiTrack/templates/admin/base_site.html
+++ b/EquiTrack/templates/admin/base_site.html
@@ -29,7 +29,8 @@
 
     .header #branding h1 {
         text-shadow: none;
-        width: 300px;
+        white-space: nowrap;
+        width:auto;
     }
    .header a:link, a:visited {
         text-decoration: none;
@@ -58,10 +59,16 @@
         font-weight: 300;
     }
 
+    #header .logo #test-text {
+        display:none;
+        color:#e6e600;
+    }
+
     .header #user-tools, #country-select {
         padding: 15px 20px 0 0;
         float: right;
     }
+
 
     /* Footer */
     #footer
@@ -82,20 +89,6 @@
         padding-top: 22px;
         padding-right: 40px;
 
-    }
-
-    #testbar {
-        height:14px;
-        display:none;
-        position:relative;
-        background-color:indianred;
-        text-align:center;
-        font-family: 'Open Sans', sans-serif;
-        font-size:10px;
-        font-weight: bold;
-        color: #ffffff;
-        overflow:hidden;
-        width:100%;
     }
 
    /* ==========================================================================
@@ -148,9 +141,15 @@
     </script>
     <script>
      $(document).ready(function () {
+         var host = {
+             'localhost'                : 'Local Testing Environment',
+             'etools-dev.unicef.org'    : 'Develop Testing Environment',
+             'etools-staging.unicef.org': 'Staging Testing Environment'
+         };
          var cond = /localhost|etools-dev|etools-staging/g;
         if (cond.test(window.location)) {
-            $('#testbar').show();
+            $('#header').css({'background': '#BE1A1A'});
+            $('#test-text').show().text(" " + host[window.location.hostname]);
         }
     });
 
@@ -158,15 +157,12 @@
 {% endblock %}
 
 {% block title %}{{ title }} | eTools{% endblock %}
-{% block topheader %}
-    <div id="testbar">Testing environment</div>
-{% endblock %}
 {% block branding %}
 
 
 
     <section id="container">
-    <div id="site-name"><img class="logoimg" src="{{ STATIC_URL }}img/UNICEF_logo_white.png" width="100" style="padding-right: 30px" ><a href="{% url 'admin:index' %}" class="logo">e<span>Tools</span></a></div>
+    <div id="site-name"><img class="logoimg" src="{{ STATIC_URL }}img/UNICEF_logo_white.png" width="100" style="padding-right: 30px" ><a href="{% url 'admin:index' %}" class="logo">e<span>Tools<span id="test-text"></span></span></a></div>
 {% endblock %}
 {% block usertools %}
         {% if has_permission %}

--- a/EquiTrack/templates/base.html
+++ b/EquiTrack/templates/base.html
@@ -45,21 +45,6 @@
     <script src="{{STATIC_URL}}js/html5shiv.js"></script>
     <script src="{{STATIC_URL}}js/respond.min.js"></script>
     <![endif]-->
-    <style>
-        #testbar {
-            height:14px;
-            display:none;
-            position:relative;
-            background-color:indianred;
-            text-align:center;
-            font-family: 'Open Sans', sans-serif;
-            font-size:10px;
-            font-weight: bold;
-            color: #ffffff;
-            overflow:hidden;
-            width:100%;
-        }
-    </style>
     {% block extra_head %}
     {% endblock %}
 
@@ -67,7 +52,6 @@
 
 {% block body %}
     <body class="animated fadeIn">
-    <div id="testbar">Testing environment</div>
 
 
     <section id="container">
@@ -78,7 +62,7 @@
                 <div></div>
                 <div class="brand">
                     <img class="logoimg" src="{{ STATIC_URL }}img/UNICEF_logo_white.png" width="100px" >
-                    <a href="{% url 'dashboard' %}" class="logo"><span>e</span>Tools</a>
+                    <a href="{% url 'dashboard' %}" class="logo"><span>e</span>Tools<span id="test-text">Testing Environment</span></a>
                 </div>
                 <!--logo end-->
 
@@ -323,9 +307,15 @@
     </script>
 <script>
      $(document).ready(function () {
+         var host = {
+             'localhost'                : 'Local Testing Environment',
+             'etools-dev.unicef.org'    : 'Develop Testing Environment',
+             'etools-staging.unicef.org': 'Staging Testing Environment'
+         };
          var cond = /localhost|etools-dev|etools-staging/g;
         if (cond.test(window.location)) {
-            $('#testbar').show();
+            $('#header').css({'background': '#BE1A1A'});
+            $('#test-text').show().text(' ' + host[window.location.hostname]);
         }
     });
 


### PR DESCRIPTION
Remove "Testing Environment" top bar.
Change banner in localhost, etools-dev, and etools-staging to be red
and display "Local Testing Environment", "Develop Testing Environment",
and "Staging Testing Environment" on banner respectively.