### PR TITLE
Catch Empty coordinates

### DIFF
--- a/EquiTrack/templates/map.html
+++ b/EquiTrack/templates/map.html
@@ -161,10 +161,18 @@
         var searchUrl = locationsUrl + query;
 
         $.getJSON(searchUrl, function(data) {
+
             updateMap(data);
             updateResultsLabel(data.length);
             toggleSpinner();
+        })
+        .fail(function(error) {
+            if (error.status == 424) {
+                alert("There are locations that do not have any coordinates, please update them accordingly!");
+                toggleSpinner();
+            }
         });
+
     }
 
     function toggleSpinner() {


### PR DESCRIPTION
On the map loading, we get 500 error when there are empty coordinates for locations.
Caught the error and added alert message on the map.