### PR TITLE
feature add result type subactivity

### DIFF
--- a/EquiTrack/reports/fixtures/initial_data.json
+++ b/EquiTrack/reports/fixtures/initial_data.json
@@ -1,17 +1,22 @@
 [
-  {
-    "pk": 1,
-    "model": "reports.resulttype",
-    "fields": {"name": "Outcome"}
-  },
-  {
-    "pk": 2,
-    "model": "reports.resulttype",
-    "fields": {"name": "Output"}
-  },
-  {
-    "pk": 3,
-    "model": "reports.resulttype",
-    "fields": {"name": "Activity"}
-  }
+    {
+        "pk": 1,
+        "model": "reports.resulttype",
+        "fields": {"name": "Outcome"}
+    },
+    {
+        "pk": 2,
+        "model": "reports.resulttype",
+        "fields": {"name": "Output"}
+    },
+    {
+        "pk": 3,
+        "model": "reports.resulttype",
+        "fields": {"name": "Activity"}
+    },
+    {
+        "pk": 4,
+        "model": "reports.resulttype",
+        "fields": {"name": "SubActivity"}
+    }
 ]

--- a/EquiTrack/reports/fixtures/initial_data.json
+++ b/EquiTrack/reports/fixtures/initial_data.json
@@ -17,6 +17,6 @@
     {
         "pk": 4,
         "model": "reports.resulttype",
-        "fields": {"name": "SubActivity"}
+        "fields": {"name": "Sub-activity"}
     }
 ]


### PR DESCRIPTION
PL19

Do we need to do anything else other than letting users put an activity to parent and use SubActivity as type? I can see there's some logic based on ResultType in `ProgrammeSynchronizer._save_records(self, records)`. 
