### PR TITLE
Django settings CACHES for redis in production [#216]

### DIFF
--- a/EquiTrack/EquiTrack/settings/production.py
+++ b/EquiTrack/EquiTrack/settings/production.py
@@ -219,3 +219,12 @@ JWT_AUTH = {
     'JWT_AUTH_HEADER_PREFIX': 'JWT',
 }
 ######## END JWT AUTH CONFIGURATION
+
+########## CACHE CONFIGURATION
+CACHES = {
+    'default': {
+        'BACKEND': 'redis_cache.RedisCache',
+        'LOCATION': environ.get('REDIS_CACHE_ADDRESS', 'localhost:6379'),
+    }
+}
+########## END CACHE CONFIGURATION

--- a/EquiTrack/EquiTrack/settings/production.py
+++ b/EquiTrack/EquiTrack/settings/production.py
@@ -224,7 +224,7 @@ JWT_AUTH = {
 CACHES = {
     'default': {
         'BACKEND': 'redis_cache.RedisCache',
-        'LOCATION': environ.get('REDIS_CACHE_ADDRESS', 'localhost:6379'),
+        'LOCATION': environ.get('REDIS_URL', 'redis://localhost:6379/0')
     }
 }
 ########## END CACHE CONFIGURATION


### PR DESCRIPTION
This PR addresses using redis as Django cache backend in the production environment.

It expects to get REDIS_CACHE_ADDRESS as environment variable. 