### PR TITLE
Agreements API fixes

### DIFF
--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -608,6 +608,11 @@ def get_agreement_path(instance, filename):
     )
 
 
+class AgreementManager(models.Manager):
+    def get_queryset(self):
+        return super(AgreementManager, self).get_queryset().select_related('partner')
+
+
 class Agreement(TimeStampedModel):
 
     PCA = u'PCA'
@@ -686,6 +691,9 @@ class Agreement(TimeStampedModel):
         help_text='Routing Details, including SWIFT/IBAN (if applicable)'
     )
     bank_contact_person = models.CharField(max_length=255, null=True, blank=True)
+
+    view_objects = AgreementManager()
+    objects = models.Manager()
 
     def __unicode__(self):
         return u'{} for {} ({} - {})'.format(

--- a/EquiTrack/partners/permissions.py
+++ b/EquiTrack/partners/permissions.py
@@ -24,16 +24,16 @@ class PartnerManagerPermission(permissions.BasePermission):
     message = 'Accessing this Intervention is not allowed.'
 
     def has_permission(self, request, view):
-        if request.user.profile.partner_staff_member:
-            return True
         if request.user.is_staff and request.method in permissions.SAFE_METHODS:
+            return True
+        if request.user.profile.partner_staff_member:
             return True
 
     def has_object_permission(self, request, view, obj):
+        if request.user.is_staff and request.method in permissions.SAFE_METHODS:
+            return True
         if request.user.profile.partner_staff_member in \
                 obj.partner.partnerstaffmember_set.values_list('id', flat=True):
-            return True
-        if request.user.is_staff and request.method in permissions.SAFE_METHODS:
             return True
 
 

--- a/EquiTrack/partners/serializers/serializers_v2.py
+++ b/EquiTrack/partners/serializers/serializers_v2.py
@@ -23,7 +23,6 @@ class AgreementListSerializer(serializers.ModelSerializer):
             "status",
             "partner_manager",
             "signed_by",
-            "attached_agreement",
         )
 
 

--- a/EquiTrack/partners/serializers/serializers_v2.py
+++ b/EquiTrack/partners/serializers/serializers_v2.py
@@ -69,12 +69,12 @@ class AgreementSerializer(serializers.ModelSerializer):
             errors.update(start=start_errors)
 
         if xor(bool(data.get("signed_by_partner_date", None)), bool(data.get("partner_manager", None))):
-            errors.update(partner_manager=["partner_manager and signed_by_partner_date are both must be provided."])
-            errors.update(signed_by_partner_date=["signed_by_partner_date and partner_manager are both must be provided."])
+            errors.update(partner_manager=["partner_manager and signed_by_partner_date must be provided."])
+            errors.update(signed_by_partner_date=["signed_by_partner_date and partner_manager must be provided."])
 
         if xor(bool(data.get("signed_by_unicef_date", None)), bool(data.get("signed_by", None))):
-            errors.update(signed_by=["signed_by and signed_by_unicef_date are both must be provided."])
-            errors.update(signed_by_unicef_date=["signed_by_unicef_date and signed_by are both must be provided."])
+            errors.update(signed_by=["signed_by and signed_by_unicef_date must be provided."])
+            errors.update(signed_by_unicef_date=["signed_by_unicef_date and signed_by must be provided."])
 
         if data.get("agreement_type", None) in [Agreement.PCA, Agreement.SSFA] and data.get("partner", None):
             partner = data.get("partner", None)

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -568,10 +568,10 @@ class TestAgreementAPIView(APITenantTestCase):
         )
 
         self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data["signed_by_partner_date"], ["signed_by_partner_date and partner_manager are both must be provided."])
-        self.assertEquals(response.data["partner_manager"], ["partner_manager and signed_by_partner_date are both must be provided."])
-        self.assertEquals(response.data["signed_by_unicef_date"], ["signed_by_unicef_date and signed_by are both must be provided."])
-        self.assertEquals(response.data["signed_by"], ["signed_by and signed_by_unicef_date are both must be provided."])
+        self.assertEquals(response.data["signed_by_partner_date"], ["signed_by_partner_date and partner_manager must be provided."])
+        self.assertEquals(response.data["partner_manager"], ["partner_manager and signed_by_partner_date must be provided."])
+        self.assertEquals(response.data["signed_by_unicef_date"], ["signed_by_unicef_date and signed_by must be provided."])
+        self.assertEquals(response.data["signed_by"], ["signed_by and signed_by_unicef_date must be provided."])
         self.assertEquals(response.data["start"], ["Start date must be provided along with end date.", "Start date must equal to the most recent signoff date (either signed_by_unicef_date or signed_by_partner_date)."])
 
     def test_agreements_update_validation_signed_date(self):
@@ -587,10 +587,10 @@ class TestAgreementAPIView(APITenantTestCase):
         )
 
         self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data["signed_by_partner_date"], ["signed_by_partner_date and partner_manager are both must be provided."])
-        self.assertEquals(response.data["partner_manager"], ["partner_manager and signed_by_partner_date are both must be provided."])
-        self.assertEquals(response.data["signed_by_unicef_date"], ["signed_by_unicef_date and signed_by are both must be provided."])
-        self.assertEquals(response.data["signed_by"], ["signed_by and signed_by_unicef_date are both must be provided."])
+        self.assertEquals(response.data["signed_by_partner_date"], ["signed_by_partner_date and partner_manager must be provided."])
+        self.assertEquals(response.data["partner_manager"], ["partner_manager and signed_by_partner_date must be provided."])
+        self.assertEquals(response.data["signed_by_unicef_date"], ["signed_by_unicef_date and signed_by must be provided."])
+        self.assertEquals(response.data["signed_by"], ["signed_by and signed_by_unicef_date must be provided."])
 
     def test_agreements_update_validation_end_date_pca(self):
         data = {

--- a/EquiTrack/partners/views/views_v2.py
+++ b/EquiTrack/partners/views/views_v2.py
@@ -55,6 +55,7 @@ class AgreementListAPIView(ListCreateAPIView):
         )
 
     def get_queryset(self):
+        q = Agreement.view_objects
         query_params = self.request.query_params
 
         if query_params:
@@ -77,9 +78,9 @@ class AgreementListAPIView(ListCreateAPIView):
                 )
 
             expression = functools.reduce(operator.and_, queries)
-            return Agreement.objects.filter(expression)
+            return q.filter(expression)
         else:
-            return super(AgreementListAPIView, self).get_queryset()
+            return q.all()
 
 
 class AgreementInterventionsListAPIView(ListAPIView):


### PR DESCRIPTION
- We originally agreed to put attached_agreement field but am removing from serializer because it will take time to serialize url from the FileField.
- To speed up API added related manager ind the model and used it in the list view.
- Will be adding another serializer to get all related models serialized for agreements. This will be used to cache all data in the fronted.