### PR TITLE
Fix - Faker pip requirement overriding

### DIFF
--- a/EquiTrack/requirements/base.txt
+++ b/EquiTrack/requirements/base.txt
@@ -64,6 +64,7 @@ django-debug-toolbar==1.6 # add debug-toolbar to be able to test in dev while we
 # Testing packages
 coverage==4.2
 factory-boy==2.7.0
+Faker==0.7.4 # A temporary fix for factory-boy library until there is a new release for factory-boy
 freezegun==0.3.8
 
 # Git python packages


### PR DESCRIPTION
This PR addresses a temporary fix for factory-boy library to work until there is a new version to fix it permanently.