### PR TITLE
Add monitoring visits api

### DIFF
--- a/EquiTrack/t2f/filters/__init__.py
+++ b/EquiTrack/t2f/filters/__init__.py
@@ -1,6 +1,7 @@
 from __future__ import unicode_literals
 
 from django.db.models.query_utils import Q
+from django.db.models import F
 from rest_framework.filters import BaseFilterBackend
 
 from t2f.serializers.filters import SearchFilterSerializer
@@ -14,7 +15,10 @@ class TravelRelatedModelFilter(BaseFilterBackend):
 
 class TravelActivityPartnerFilter(BaseFilterBackend):
     def filter_queryset(self, request, queryset, view):
-        return queryset.filter(partner__pk=view.kwargs['partner_organization_pk']).prefetch_related('travels')
+        return queryset \
+                .filter(partner__pk=view.kwargs['partner_organization_pk']) \
+                .prefetch_related('travels') \
+                .filter(travels__traveler=F("primary_traveler"))
 
 
 class BaseSearchFilter(BaseFilterBackend):

--- a/EquiTrack/t2f/filters/__init__.py
+++ b/EquiTrack/t2f/filters/__init__.py
@@ -12,6 +12,11 @@ class TravelRelatedModelFilter(BaseFilterBackend):
         return queryset.filter(travel__pk=view.kwargs['travel_pk'])
 
 
+class TravelActivityPartnerFilter(BaseFilterBackend):
+    def filter_queryset(self, request, queryset, view):
+        return queryset.filter(partner__pk=view.kwargs['partner_organization_pk']).prefetch_related('travels')
+
+
 class BaseSearchFilter(BaseFilterBackend):
     _search_fields = ()
 

--- a/EquiTrack/t2f/serializers/__init__.py
+++ b/EquiTrack/t2f/serializers/__init__.py
@@ -443,6 +443,16 @@ class TravelListSerializer(TravelDetailsSerializer):
         read_only_fields = ('status',)
 
 
+class TravelActivityByPartnerSerializer(serializers.ModelSerializer):
+    locations = serializers.SlugRelatedField(slug_field='name', many=True, read_only=True)
+    travels = TravelListSerializer(many=True)
+    primary_traveler = serializers.CharField(source='primary_traveler.get_full_name')
+
+    class Meta:
+        model = TravelActivity
+        fields = ("primary_traveler", "travel_type", "date", "locations", "travels",)
+
+
 class CloneOutputSerializer(TravelDetailsSerializer):
     class Meta:
         model = Travel

--- a/EquiTrack/t2f/serializers/__init__.py
+++ b/EquiTrack/t2f/serializers/__init__.py
@@ -445,12 +445,19 @@ class TravelListSerializer(TravelDetailsSerializer):
 
 class TravelActivityByPartnerSerializer(serializers.ModelSerializer):
     locations = serializers.SlugRelatedField(slug_field='name', many=True, read_only=True)
-    travels = TravelListSerializer(many=True)
     primary_traveler = serializers.CharField(source='primary_traveler.get_full_name')
+    reference_number = serializers.SerializerMethodField()
+    status = serializers.SerializerMethodField()
+
+    def get_status(self, obj):
+        return obj.travels.first().status
+
+    def get_reference_number(self, obj):
+        return obj.travels.first().reference_number
 
     class Meta:
         model = TravelActivity
-        fields = ("primary_traveler", "travel_type", "date", "locations", "travels",)
+        fields = ("primary_traveler", "travel_type", "date", "locations", "reference_number", "status",)
 
 
 class CloneOutputSerializer(TravelDetailsSerializer):

--- a/EquiTrack/t2f/tests/test_travel_list.py
+++ b/EquiTrack/t2f/tests/test_travel_list.py
@@ -341,7 +341,7 @@ class TravelActivityList(APITenantTestCase):
         self.travel_activity = TravelActivityFactory(primary_traveler=self.traveler2)
 
     def test_list_view(self):
-        with self.assertNumQueries(7):
+        with self.assertNumQueries(8):
             response = self.forced_auth_req(
                 'get',
                 reverse(
@@ -352,7 +352,7 @@ class TravelActivityList(APITenantTestCase):
             )
 
         response_json = json.loads(response.rendered_content)
-        expected_keys = ["primary_traveler", "travel_type", "date", "locations", "travels"]
+        expected_keys = ["primary_traveler", "travel_type", "date", "locations", "status", "reference_number"]
 
         self.assertKeysIn(expected_keys, response_json[0])
         self.assertEqual(len(response_json), 1)

--- a/EquiTrack/t2f/tests/test_travel_list.py
+++ b/EquiTrack/t2f/tests/test_travel_list.py
@@ -15,7 +15,7 @@ from publics.models import DSARegion
 from t2f.models import ModeOfTravel, make_travel_reference_number, Travel, TravelType
 from t2f.tests.factories import AirlineCompanyFactory, CurrencyFactory, FundFactory
 
-from .factories import TravelFactory
+from .factories import TravelFactory, TravelActivityFactory
 
 log = logging.getLogger('__name__')
 
@@ -325,3 +325,34 @@ class TravelList(APITenantTestCase):
                                         data=data, user=self.unicef_staff)
         response_json = json.loads(response.rendered_content)
         self.assertEqual(len(response_json['itinerary']), 1)
+
+
+class TravelActivityList(APITenantTestCase):
+
+    def setUp(self):
+        super(TravelActivityList, self).setUp()
+        self.unicef_staff = UserFactory(is_staff=True)
+        self.traveler1 = UserFactory()
+        self.traveler2 = UserFactory()
+        self.travel = TravelFactory(reference_number=make_travel_reference_number(),
+                                    traveler=self.traveler1,
+                                    supervisor=self.unicef_staff)
+        # to filter against
+        self.travel_activity = TravelActivityFactory(primary_traveler=self.traveler2)
+
+    def test_list_view(self):
+        with self.assertNumQueries(7):
+            response = self.forced_auth_req(
+                'get',
+                reverse(
+                    't2f:travels:list:activities',
+                    kwargs={"partner_organization_pk": self.travel.activities.first().partner.id}
+                ),
+                user=self.unicef_staff,
+            )
+
+        response_json = json.loads(response.rendered_content)
+        expected_keys = ["primary_traveler", "travel_type", "date", "locations", "travels"]
+
+        self.assertKeysIn(expected_keys, response_json[0])
+        self.assertEqual(len(response_json), 1)

--- a/EquiTrack/t2f/urls.py
+++ b/EquiTrack/t2f/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import url, patterns, include
 
 from t2f.views import TravelListViewSet, TravelDetailsViewSet, StaticDataView, PermissionMatrixView, \
     TravelAttachmentViewSet, ActionPointViewSet, InvoiceViewSet, VendorNumberListView, VisionInvoiceExport, \
-    VisionInvoiceUpdate
+    VisionInvoiceUpdate, TravelActivityViewSet
 
 travel_list = TravelListViewSet.as_view({'get': 'list',
                                          'post': 'create'})
@@ -57,6 +57,7 @@ travel_list_patterns = patterns(
     url(r'^travel-admin-export/$', TravelListViewSet.as_view({'get': 'export_travel_admins'}),
         name='travel_admin_export'),
     url(r'^invoice-export/$', TravelListViewSet.as_view({'get': 'export_invoices'}), name='invoice_export'),
+    url(r'^activities/(?P<partner_organization_pk>[0-9]+)/', TravelActivityViewSet.as_view({'get': 'list'}), name='activities'),
 )
 
 

--- a/EquiTrack/t2f/views.py
+++ b/EquiTrack/t2f/views.py
@@ -23,7 +23,7 @@ from rest_framework_xml.parsers import XMLParser
 from rest_framework_xml.renderers import XMLRenderer
 
 from publics.models import TravelExpenseType
-from t2f.filters import TravelRelatedModelFilter
+from t2f.filters import TravelRelatedModelFilter, TravelActivityPartnerFilter
 from t2f.filters import travel_list, action_points, invoices
 from locations.models import Location
 from partners.models import PartnerOrganization, Intervention
@@ -32,9 +32,10 @@ from t2f.serializers.export import TravelListExportSerializer, FinanceExportSeri
     InvoiceExportSerializer
 
 from t2f.models import Travel, TravelAttachment, TravelType, ModeOfTravel, ActionPoint, Invoice, IteneraryItem, \
-    InvoiceItem
+    InvoiceItem, TravelActivity
 from t2f.serializers import TravelListSerializer, TravelDetailsSerializer, TravelAttachmentSerializer, \
-    CloneParameterSerializer, CloneOutputSerializer, ActionPointSerializer, InvoiceSerializer
+    CloneParameterSerializer, CloneOutputSerializer, ActionPointSerializer, InvoiceSerializer, \
+    TravelActivityByPartnerSerializer
 from t2f.serializers.static_data import StaticDataSerializer
 from t2f.helpers import PermissionMatrix, CloneTravelHelper, FakePermissionMatrix
 from t2f.permission_matrix import PERMISSION_MATRIX
@@ -249,6 +250,15 @@ class TravelAttachmentViewSet(mixins.ListModelMixin,
         travel = get_object_or_404(queryset, pk=self.kwargs['travel_pk'])
         context['travel'] = travel
         return context
+
+
+class TravelActivityViewSet(mixins.ListModelMixin,
+                            viewsets.GenericViewSet):
+    queryset = TravelActivity.objects.all()
+    permission_classes = (IsAdminUser,)
+    serializer_class = TravelActivityByPartnerSerializer
+    filter_backends = (TravelActivityPartnerFilter,)
+    lookup_url_kwarg = 'partner_organization_pk'
 
 
 class ActionPointViewSet(mixins.ListModelMixin,

--- a/EquiTrack/t2f/views.py
+++ b/EquiTrack/t2f/views.py
@@ -260,7 +260,6 @@ class TravelActivityViewSet(mixins.ListModelMixin,
     filter_backends = (TravelActivityPartnerFilter,)
     lookup_url_kwarg = 'partner_organization_pk'
 
-
 class ActionPointViewSet(mixins.ListModelMixin,
                          mixins.RetrieveModelMixin,
                          mixins.UpdateModelMixin,


### PR DESCRIPTION
@robertavram said:

Look at this screen:
https://projects.invisionapp.com/share/XQ90VSSC7#/screens/205455281
notice MonitoringVisits.
Build an api endpoint that takes in a partner organization ID, Gets all the travels with those fields.  Basically what you'll have to do is:
get all The travel_activities that connect to the Partner Oganization.
In order to get the travel you'll have to get all the Travels where the traveller is equal to TravelActivity primary_traveler