### PR TITLE
Fix trips dashboard no section error

### DIFF
--- a/EquiTrack/t2f/tests/test_travel_list.py
+++ b/EquiTrack/t2f/tests/test_travel_list.py
@@ -95,7 +95,7 @@ class TravelList(APITenantTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected_keys = ['travels_by_section', 'completed', 'planned', 'approved']
         self.assertKeysIn(expected_keys, response_json)
-        self.assertEqual(response_json['travels_by_section'][0]['section_name'], 'no_section_selected')
+        self.assertEqual(response_json['travels_by_section'][0]['section_name'], 'No Section selected')
         self.assertEqual(len(response_json['travels_by_section']), 1)
         self.assertEqual(response_json['planned'], 1)
 

--- a/EquiTrack/t2f/tests/test_travel_list.py
+++ b/EquiTrack/t2f/tests/test_travel_list.py
@@ -48,7 +48,7 @@ class TravelList(APITenantTestCase):
         self.assertKeysIn(expected_keys, travel_data)
 
     def test_dashboard_travels_list_view(self):
-        with self.assertNumQueries(12):
+        with self.assertNumQueries(10):
             response = self.forced_auth_req(
                 'get',
                 reverse(
@@ -67,6 +67,35 @@ class TravelList(APITenantTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         expected_keys = ['travels_by_section', 'completed', 'planned', 'approved']
         self.assertKeysIn(expected_keys, response_json)
+        self.assertEqual(len(response_json['travels_by_section']), 1)
+        self.assertEqual(response_json['planned'], 1)
+
+    def test_dashboard_travels_list_view_no_section(self):
+        travel = TravelFactory(reference_number=make_travel_reference_number(),
+                                    traveler=self.traveler,
+                                    supervisor=self.unicef_staff,
+                                    section=None)
+
+        with self.assertNumQueries(10):
+            response = self.forced_auth_req(
+                'get',
+                reverse(
+                    't2f:travels:list:dashboard',
+                    kwargs={
+                        "year": travel.start_date.year,
+                        "month": '{month:02d}'.format(month=travel.start_date.month),
+                    }
+                ),
+                user=self.unicef_staff,
+                data={"office_id": travel.office.id}
+            )
+
+        response_json = json.loads(response.rendered_content)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        expected_keys = ['travels_by_section', 'completed', 'planned', 'approved']
+        self.assertKeysIn(expected_keys, response_json)
+        self.assertEqual(response_json['travels_by_section'][0]['section_name'], 'no_section_selected')
         self.assertEqual(len(response_json['travels_by_section']), 1)
         self.assertEqual(response_json['planned'], 1)
 

--- a/EquiTrack/t2f/tests/test_travel_list.py
+++ b/EquiTrack/t2f/tests/test_travel_list.py
@@ -100,7 +100,7 @@ class TravelList(APITenantTestCase):
         self.assertEqual(response_json['planned'], 1)
 
     def test_dashboard_action_points_list_view(self):
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             response = self.forced_auth_req(
                 'get',
                 reverse('t2f:action_points:dashboard'),
@@ -117,7 +117,7 @@ class TravelList(APITenantTestCase):
         self.assertEqual(response_json['action_points_by_section'][0]['total_action_points'], 1)
 
     def test_dashboard_action_points_list_view_no_office(self):
-        with self.assertNumQueries(8):
+        with self.assertNumQueries(6):
             response = self.forced_auth_req(
                 'get',
                 reverse('t2f:action_points:dashboard'),

--- a/EquiTrack/t2f/views/dashboard.py
+++ b/EquiTrack/t2f/views/dashboard.py
@@ -70,9 +70,10 @@ class ActionPointDashboardViewSet(mixins.ListModelMixin,
                 action_points = ActionPoint.objects.filter(travel__in=travels)
                 total = action_points.count()
                 completed = action_points.filter(status=Travel.COMPLETED).count()
+                section = travels.first().section
                 section_action_points = {
-                    "section_id": travels.first().section.id,
-                    "section_name": travels.first().section.name,
+                    "section_id": section.id if section else None,
+                    "section_name": section.name if section else "no_section_selected",
                     "total_action_points": total,
                     "completed_action_points": completed,
                 }

--- a/EquiTrack/t2f/views/dashboard.py
+++ b/EquiTrack/t2f/views/dashboard.py
@@ -36,9 +36,10 @@ class TravelDashboardViewSet(mixins.ListModelMixin,
                 planned = travels.filter(status=Travel.PLANNED).count()
                 approved = travels.filter(status=Travel.APPROVED).count()
                 completed = travels.filter(status=Travel.COMPLETED).count()
+                section = travels.first().section
                 section_trips = {
-                    "section_id": travels.first().section.id,
-                    "section_name": travels.first().section.name,
+                    "section_id": section.id if section else None,
+                    "section_name": section.name if section else "no_section_selected",
                     "planned_travels": planned,
                     "approved_travels": approved,
                     "completed_travels": completed,

--- a/EquiTrack/t2f/views/dashboard.py
+++ b/EquiTrack/t2f/views/dashboard.py
@@ -39,7 +39,7 @@ class TravelDashboardViewSet(mixins.ListModelMixin,
                 section = travels.first().section
                 section_trips = {
                     "section_id": section.id if section else None,
-                    "section_name": section.name if section else "no_section_selected",
+                    "section_name": section.name if section else "No Section selected",
                     "planned_travels": planned,
                     "approved_travels": approved,
                     "completed_travels": completed,
@@ -73,7 +73,7 @@ class ActionPointDashboardViewSet(mixins.ListModelMixin,
                 section = travels.first().section
                 section_action_points = {
                     "section_id": section.id if section else None,
-                    "section_name": section.name if section else "no_section_selected",
+                    "section_name": section.name if section else "No Section selected",
                     "total_action_points": total,
                     "completed_action_points": completed,
                 }


### PR DESCRIPTION
Frontend needs to be aligned.

For travels_by_section that have no Section associated, section_id is null and section_name is "no_section_selected". Frontend should say "No Section Selected" instead of Section name.