### PR TITLE
fix wrong Q lookup at first save

### DIFF
--- a/EquiTrack/t2f/serializers/travel.py
+++ b/EquiTrack/t2f/serializers/travel.py
@@ -311,7 +311,10 @@ class TravelDetailsSerializer(serializers.ModelSerializer):
                 travel_q = Q(traveler=traveler)
                 travel_q &= ~Q(status__in=[Travel.PLANNED, Travel.CANCELLED])
                 travel_q &= Q(start_date__range=(start_date, end_date)) | Q(end_date__range=(start_date, end_date))
-                travel_q &= ~Q(id=self.instance.id)
+
+                # In case of first save, no id present
+                if self.instance:
+                    travel_q &= ~Q(id=self.instance.id)
 
                 if Travel.objects.filter(travel_q).exists():
                     raise ValidationError(ugettext('You have an existing trip with overlapping dates. '

--- a/EquiTrack/t2f/tests/test_state_machine.py
+++ b/EquiTrack/t2f/tests/test_state_machine.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import json
 from collections import defaultdict
+from datetime import datetime, timedelta
 
 from django.core.urlresolvers import reverse
 
@@ -96,21 +97,24 @@ class StateMachineTest(APITenantTestCase):
                                                         kwargs={'travel_pk': travel_id,
                                                                 'transition_name': 'submit_for_approval'}),
                                         data=data, user=self.unicef_staff)
+        response_json = json.loads(response.rendered_content)
 
         response = self.forced_auth_req('post', reverse('t2f:travels:details:state_change',
                                                         kwargs={'travel_pk': travel_id,
                                                                 'transition_name': 'approve'}),
-                                        data=data, user=self.unicef_staff)
+                                        data=response_json, user=self.unicef_staff)
+        response_json = json.loads(response.rendered_content)
 
         response = self.forced_auth_req('post', reverse('t2f:travels:details:state_change',
                                                         kwargs={'travel_pk': travel_id,
                                                                 'transition_name': 'send_for_payment'}),
-                                        data=data, user=self.unicef_staff)
+                                        data=response_json, user=self.unicef_staff)
+        response_json = json.loads(response.rendered_content)
 
         response = self.forced_auth_req('post', reverse('t2f:travels:details:state_change',
                                                         kwargs={'travel_pk': travel_id,
                                                                 'transition_name': 'mark_as_certified'}),
-                                        data=data, user=self.unicef_staff)
+                                        data=response_json, user=self.unicef_staff)
 
         response_json = json.loads(response.rendered_content)
         self.assertEqual(response_json['non_field_errors'], ['Your TA has pending payments to be processed through '
@@ -159,6 +163,8 @@ class StateMachineTest(APITenantTestCase):
         data = {'traveler': self.traveler.id,
                 'ta_required': False,
                 'international_travel': False,
+                'start_date': datetime.utcnow(),
+                'end_date': datetime.utcnow() + timedelta(hours=10),
                 'supervisor': self.unicef_staff.id}
         response = self.forced_auth_req('post', reverse('t2f:travels:list:state_change',
                                                         kwargs={'transition_name': 'mark_as_completed'}),
@@ -171,6 +177,8 @@ class StateMachineTest(APITenantTestCase):
         data = {'traveler': self.traveler.id,
                 'ta_required': False,
                 'international_travel': False,
+                'start_date': datetime.utcnow(),
+                'end_date': datetime.utcnow() + timedelta(hours=10),
                 'supervisor': self.unicef_staff.id}
         response = self.forced_auth_req('post', reverse('t2f:travels:list:state_change',
                                                         kwargs={'transition_name': 'save_and_submit'}),


### PR DESCRIPTION
In case of first save and submit, the serialzier threw a 500 because it tried to look up an id which does not exists yet.