### PR TITLE
Fix some weak locations API tests

### DIFF
--- a/EquiTrack/locations/tests/test_views.py
+++ b/EquiTrack/locations/tests/test_views.py
@@ -1,6 +1,7 @@
-__author__ = 'achamseddine'
 from django.db import connection
 from django.core.cache import cache
+from django.core.urlresolvers import reverse
+
 from rest_framework import status
 
 from EquiTrack.factories import UserFactory, LocationFactory
@@ -12,32 +13,33 @@ class TestLocationViews(APITenantTestCase):
 
     def setUp(self):
         self.unicef_staff = UserFactory(is_staff=True)
-        self.locations = [LocationFactory() for x in xrange(5)]
+        self.locations = [LocationFactory() for x in range(5)]
+        # heavy_detail_expected_keys are the keys that should be in response.data.keys()
+        self.heavy_detail_expected_keys = sorted(('id', 'name', 'p_code', 'location_type', 'parent', 'geo_point'))
 
     def test_api_locationtypes_list(self):
-        response = self.forced_auth_req('get', '/api/locations-types/', user=self.unicef_staff)
-
+        response = self.forced_auth_req('get', reverse('locationtypes-list'), user=self.unicef_staff)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
 
     def test_api_location_light_list(self):
-        response = self.forced_auth_req('get', '/api/locations-light/', user=self.unicef_staff)
+        response = self.forced_auth_req('get', reverse('locations-light-list'), user=self.unicef_staff)
 
         self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(response.data[0].keys(), ["id", "name", "p_code"])
         self.assertEquals(response.data[0]["name"], '{} [{} - {}]'.format(self.locations[0].name, self.locations[0].gateway.name, self.locations[0].p_code))
 
     def test_api_location_heavy_list(self):
-        response = self.forced_auth_req('get', '/api/locations/', user=self.unicef_staff)
+        response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff)
 
         self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertNotEquals(response.data[0].keys(), ["id", "name", "p_code", "geo_point"])
+        self.assertEquals(sorted(response.data[0].keys()), self.heavy_detail_expected_keys)
         self.assertIn("Location", response.data[0]["name"])
 
     def test_api_location_values(self):
         params = {"values": "{},{}".format(self.locations[0].id,self.locations[1].id)}
         response = self.forced_auth_req(
             'get',
-            '/api/locations/',
+            reverse('locations-list'),
             user=self.unicef_staff,
             data=params
         )
@@ -45,54 +47,51 @@ class TestLocationViews(APITenantTestCase):
         self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(len(response.data), 2)
 
-    def test_api_location_heavy_detail(self):
-        url = '/api/locations/{}/'.format(self.locations[0].id)
-        response = self.forced_auth_req('get', url, user=self.unicef_staff)
-
+    def _assert_heavy_detail_view_fundamentals(self, response):
+        '''Utility function that collects common assertions for heavy detail tests'''
         self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertNotEquals(response.data.keys(), ["id", "name", "p_code"])
+        self.assertEquals(sorted(response.data.keys()), self.heavy_detail_expected_keys)
         self.assertIn("Location", response.data["name"])
+
+    def test_api_location_heavy_detail(self):
+        url = reverse('locations-detail', args=[self.locations[0].id])
+        response = self.forced_auth_req('get', url, user=self.unicef_staff)
+        self._assert_heavy_detail_view_fundamentals(response)
 
     def test_api_location_heavy_detail_pk(self):
-        url = '/api/locations/{}/'.format(self.locations[0].id)
+        url = reverse('locations-detail', args=[self.locations[0].id])
         response = self.forced_auth_req('get', url, user=self.unicef_staff)
-
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertNotEquals(response.data.keys(), ["id", "name", "p_code"])
-        self.assertIn("Location", response.data["name"])
+        self._assert_heavy_detail_view_fundamentals(response)
 
     def test_api_location_heavy_detail_pcode(self):
-        url = '/api/locations/pcode/{}/'.format(self.locations[0].p_code)
+        url = reverse('locations_detail_pcode', args=[self.locations[0].p_code])
         response = self.forced_auth_req('get', url, user=self.unicef_staff)
-
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertNotEquals(response.data.keys(), ["id", "name", "p_code"])
-        self.assertIn("Location", response.data["name"])
+        self._assert_heavy_detail_view_fundamentals(response)
 
     def test_api_location_list_cached(self):
-        response = self.forced_auth_req('get', '/api/locations/', user=self.unicef_staff)
+        response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(len(response.data), 5)
         etag = response["ETag"]
 
-        response = self.forced_auth_req('get', '/api/locations/', user=self.unicef_staff, HTTP_IF_NONE_MATCH=etag)
+        response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff, HTTP_IF_NONE_MATCH=etag)
         self.assertEquals(response.status_code, status.HTTP_304_NOT_MODIFIED)
 
     def test_api_location_list_modified(self):
-        response = self.forced_auth_req('get', '/api/locations/', user=self.unicef_staff)
+        response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(len(response.data), 5)
         etag = response["ETag"]
 
-        location = LocationFactory()
+        LocationFactory()
 
-        response = self.forced_auth_req('get', '/api/locations/', user=self.unicef_staff, HTTP_IF_NONE_MATCH=etag)
+        response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff, HTTP_IF_NONE_MATCH=etag)
         self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(len(response.data), 6)
 
     def test_location_delete_etag(self):
         # Activate cache-aside with a request.
-        response = self.forced_auth_req('get', '/api/locations/', user=self.unicef_staff)
+        self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff)
         schema_name = connection.schema_name
         etag_before = cache.get("{}-locations-etag".format(schema_name))
         Location.objects.all().delete()
@@ -100,7 +99,7 @@ class TestLocationViews(APITenantTestCase):
         assert etag_before != etag_after
 
     def test_api_location_autocomplete(self):
-        response = self.forced_auth_req('get', '/locations/autocomplete/', user=self.unicef_staff, data={"q": "Loc"})
+        response = self.forced_auth_req('get', reverse('locations_autocomplete'), user=self.unicef_staff, data={"q": "Loc"})
 
         self.assertEquals(response.status_code, status.HTTP_200_OK)
         self.assertEquals(len(response.data), 5)


### PR DESCRIPTION
- In heavy detail tests, replace weak 'assert absence of' test with strong 'assert presence of' test
- consolidated common heavy detail test code into a utility function
- Fix potential bug relying on arbitrary sort order of dict keys
- Fix potential bug where `response.data["name"]` was accessed without prior verification that the `name` key existed
- In all tests in `locations/tests/test_views.py`, replaced hardcoded URLs with Django's `reverse()` function
- Fix 2 flake8 errors (already fixed in PR #630)