### PR TITLE
Update deprecated assertions (READY)

### DIFF
--- a/EquiTrack/funds/tests/test_views.py
+++ b/EquiTrack/funds/tests/test_views.py
@@ -14,9 +14,9 @@ class TestFundViews(APITenantTestCase):
     def test_api_donors_list(self):
         response = self.forced_auth_req('get', '/api/funds/donors/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_grants_list(self):
         response = self.forced_auth_req('get', '/api/funds/grants/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)

--- a/EquiTrack/locations/tests/test_views.py
+++ b/EquiTrack/locations/tests/test_views.py
@@ -19,20 +19,20 @@ class TestLocationViews(APITenantTestCase):
 
     def test_api_locationtypes_list(self):
         response = self.forced_auth_req('get', reverse('locationtypes-list'), user=self.unicef_staff)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_location_light_list(self):
         response = self.forced_auth_req('get', reverse('locations-light-list'), user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data[0].keys(), ["id", "name", "p_code"])
-        self.assertEquals(response.data[0]["name"], '{} [{} - {}]'.format(self.locations[0].name, self.locations[0].gateway.name, self.locations[0].p_code))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0].keys(), ["id", "name", "p_code"])
+        self.assertEqual(response.data[0]["name"], '{} [{} - {}]'.format(self.locations[0].name, self.locations[0].gateway.name, self.locations[0].p_code))
 
     def test_api_location_heavy_list(self):
         response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(sorted(response.data[0].keys()), self.heavy_detail_expected_keys)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(sorted(response.data[0].keys()), self.heavy_detail_expected_keys)
         self.assertIn("Location", response.data[0]["name"])
 
     def test_api_location_values(self):
@@ -44,13 +44,13 @@ class TestLocationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
     def _assert_heavy_detail_view_fundamentals(self, response):
         '''Utility function that collects common assertions for heavy detail tests'''
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(sorted(response.data.keys()), self.heavy_detail_expected_keys)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(sorted(response.data.keys()), self.heavy_detail_expected_keys)
         self.assertIn("Location", response.data["name"])
 
     def test_api_location_heavy_detail(self):
@@ -70,24 +70,24 @@ class TestLocationViews(APITenantTestCase):
 
     def test_api_location_list_cached(self):
         response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 5)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
         etag = response["ETag"]
 
         response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff, HTTP_IF_NONE_MATCH=etag)
-        self.assertEquals(response.status_code, status.HTTP_304_NOT_MODIFIED)
+        self.assertEqual(response.status_code, status.HTTP_304_NOT_MODIFIED)
 
     def test_api_location_list_modified(self):
         response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 5)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
         etag = response["ETag"]
 
         LocationFactory()
 
         response = self.forced_auth_req('get', reverse('locations-list'), user=self.unicef_staff, HTTP_IF_NONE_MATCH=etag)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 6)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 6)
 
     def test_location_delete_etag(self):
         # Activate cache-aside with a request.
@@ -101,7 +101,7 @@ class TestLocationViews(APITenantTestCase):
     def test_api_location_autocomplete(self):
         response = self.forced_auth_req('get', reverse('locations_autocomplete'), user=self.unicef_staff, data={"q": "Loc"})
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 5)
-        self.assertEquals(response.data[0].keys(), ["id", "name", "p_code"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 5)
+        self.assertEqual(response.data[0].keys(), ["id", "name", "p_code"])
         self.assertIn("Loc", response.data[0]["name"])

--- a/EquiTrack/partners/tests/test_api_interventions.py
+++ b/EquiTrack/partners/tests/test_api_interventions.py
@@ -67,6 +67,6 @@ class TestInterventionsAPI(APITenantTestCase):
             user=self.unicef_staff,
             data=data
         )
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         result = json.loads(response.rendered_content)
-        self.assertEquals(result.get('result_links'), {'name': ['This field may not be null.']})
+        self.assertEqual(result.get('result_links'), {'name': ['This field may not be null.']})

--- a/EquiTrack/partners/tests/test_exports.py
+++ b/EquiTrack/partners/tests/test_exports.py
@@ -103,7 +103,7 @@ class TestModelExport(APITenantTestCase):
             data={"format": "csv"},
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         dataset = Dataset().load(response.content, 'csv')
         self.assertEqual(dataset.height, 1)
         self.assertEqual(dataset._get_headers(), [
@@ -197,7 +197,7 @@ class TestModelExport(APITenantTestCase):
             data={"format": "csv"},
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         dataset = Dataset().load(response.content, 'csv')
         self.assertEqual(dataset.height, 2)
         self.assertEqual(dataset._get_headers(), [
@@ -241,7 +241,7 @@ class TestModelExport(APITenantTestCase):
             data={"format": "csv"},
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         dataset = Dataset().load(response.content, 'csv')
         self.assertEqual(dataset.height, 2)
         self.assertEqual(dataset._get_headers(), [

--- a/EquiTrack/partners/tests/test_models.py
+++ b/EquiTrack/partners/tests/test_models.py
@@ -592,23 +592,23 @@ class TestAgreementModel(TenantTestCase):
         self.agreement.save()
 
         # Check if new activity action has been created
-        self.assertEquals(model_stream(Agreement).count(), 2)
+        self.assertEqual(model_stream(Agreement).count(), 2)
 
         # Check the previous content
         previous = model_stream(Agreement).first().data['previous']
-        self.assertNotEquals(previous, {})
+        self.assertNotEqual(previous, {})
 
         # Check the changes content
         changes = model_stream(Agreement).first().data['changes']
-        self.assertNotEquals(changes, {})
+        self.assertNotEqual(changes, {})
 
         # Check if the previous had the empty date fields
-        self.assertEquals(previous['start'], 'None')
-        self.assertEquals(previous['signed_by_unicef_date'], 'None')
+        self.assertEqual(previous['start'], 'None')
+        self.assertEqual(previous['signed_by_unicef_date'], 'None')
 
         # Check if the changes had the updated date fields
-        self.assertEquals(changes['start'], str(self.agreement.start))
-        self.assertEquals(changes['signed_by_unicef_date'], str(self.agreement.signed_by_unicef_date))
+        self.assertEqual(changes['start'], str(self.agreement.start))
+        self.assertEqual(changes['signed_by_unicef_date'], str(self.agreement.signed_by_unicef_date))
 
 
 class TestInterventionModel(TenantTestCase):

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -118,7 +118,7 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_api_partners_delete_asssessment_error(self):
         response = self.forced_auth_req(
@@ -127,14 +127,14 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["Cannot delete a completed assessment"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["Cannot delete a completed assessment"])
 
     def test_api_partners_list_restricted(self):
         response = self.forced_auth_req('get', '/api/v2/partners/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
         self.assertIn("vendor_number", response.data[0].keys())
         self.assertNotIn("address", response.data[0].keys())
 
@@ -152,7 +152,7 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_api_partners_create_with_members(self):
         staff_members = [{
@@ -175,7 +175,7 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_api_partners_update_with_members(self):
         response = self.forced_auth_req(
@@ -183,9 +183,9 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             '/api/v2/partners/{}/'.format(self.partner.id),
             user=self.unicef_staff,
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data["staff_members"]), 1)
-        self.assertEquals(response.data["staff_members"][0]["first_name"], "Mace")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["staff_members"]), 1)
+        self.assertEqual(response.data["staff_members"][0]["first_name"], "Mace")
 
         staff_members = [{
             "title": "Some title",
@@ -207,8 +207,8 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data["staff_members"]), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["staff_members"]), 2)
 
     def test_api_partners_update_assessments_invalid(self):
         today = datetime.date.today()
@@ -226,8 +226,8 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, {"assessments":
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {"assessments":
                                           {"completed_date":
                                            ["The Date of Report cannot be in the future"]}})
 
@@ -247,7 +247,7 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_partners_update_assessments_today(self):
         completed_date = datetime.date.today()
@@ -265,7 +265,7 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_partners_update_assessments_yesterday(self):
         completed_date = datetime.date.today() - timedelta(days=1)
@@ -283,7 +283,7 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_partners_update_with_members_null_phone(self):
         response = self.forced_auth_req(
@@ -291,9 +291,9 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             '/api/v2/partners/{}/'.format(self.partner.id),
             user=self.unicef_staff,
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data["staff_members"]), 1)
-        self.assertEquals(response.data["staff_members"][0]["first_name"], "Mace")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["staff_members"]), 1)
+        self.assertEqual(response.data["staff_members"][0]["first_name"], "Mace")
 
         staff_members = [{
             "title": "Some title",
@@ -313,9 +313,9 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["staff_members"][1]["phone"], None)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["staff_members"][1]["phone"], None)
 
     def test_api_partners_update_assessments_tomorrow(self):
         completed_date = datetime.date.today() + timedelta(days=1)
@@ -333,8 +333,8 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, {"assessments":
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, {"assessments":
                                           {"completed_date":
                                            ["The Date of Report cannot be in the future"]}})
 
@@ -345,14 +345,14 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("vendor_number", response.data.keys())
         self.assertIn("address", response.data.keys())
         self.assertIn("Partner", response.data["name"])
-        self.assertEquals(['programme_visits', 'spot_checks'], response.data["hact_min_requirements"].keys())
-        self.assertEquals(['audits_done', 'planned_visits', 'spot_checks', 'programmatic_visits', 'follow_up_flags',
+        self.assertEqual(['programme_visits', 'spot_checks'], response.data["hact_min_requirements"].keys())
+        self.assertEqual(['audits_done', 'planned_visits', 'spot_checks', 'programmatic_visits', 'follow_up_flags',
                            'planned_cash_transfer', 'micro_assessment_needed', 'audits_mr'], response.data["hact_values"].keys())
-        self.assertEquals(response.data['interventions'], [])
+        self.assertEqual(response.data['interventions'], [])
 
     def test_api_partners_retrieve_staff_members(self):
         response = self.forced_auth_req(
@@ -361,9 +361,9 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("staff_members", response.data.keys())
-        self.assertEquals(len(response.data["staff_members"]), 1)
+        self.assertEqual(len(response.data["staff_members"]), 1)
 
     def test_api_partners_update(self):
         data = {
@@ -376,7 +376,7 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("Updated", response.data["name"])
 
     def test_api_partners_list_minimal(self):
@@ -388,8 +388,8 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data[0].keys(), ["id", "name"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0].keys(), ["id", "name"])
 
     def test_api_partners_filter_partner_type(self):
         # make some other type to filter against
@@ -402,10 +402,10 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
-        self.assertEquals(response.data[0]["id"], self.partner.id)
-        self.assertEquals(response.data[0]["partner_type"], PartnerType.CIVIL_SOCIETY_ORGANIZATION)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.partner.id)
+        self.assertEqual(response.data[0]["partner_type"], PartnerType.CIVIL_SOCIETY_ORGANIZATION)
 
     def test_api_partners_filter_cso_type(self):
         # make some other type to filter against
@@ -418,9 +418,9 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
-        self.assertEquals(response.data[0]["id"], self.partner.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.partner.id)
 
     def test_api_partners_filter_hidden(self):
         # make some other type to filter against
@@ -433,9 +433,9 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
-        self.assertEquals(response.data[0]["id"], self.partner.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["id"], self.partner.id)
 
     def test_api_partners_filter_multiple(self):
         # make some other type to filter against
@@ -451,8 +451,8 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 0)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 0)
 
     def test_api_partners_search_name(self):
         # make some other type to filter against
@@ -465,9 +465,9 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
-        self.assertEquals(response.data[0]["id"], self.partner.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["id"], self.partner.id)
 
     def test_api_partners_short_name(self):
         # make some other type to filter against
@@ -480,9 +480,9 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
-        self.assertEquals(response.data[0]["id"], self.partner.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.partner.id)
 
     def test_api_partners_values(self):
         # make some other instance to filter against
@@ -496,10 +496,10 @@ class TestPartnerOrganizationViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
-        self.assertEquals(response.data[0]["id"], p1.id)
-        self.assertEquals(response.data[1]["id"], p2.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(response.data[0]["id"], p1.id)
+        self.assertEqual(response.data[1]["id"], p2.id)
 
 
 class TestPartnershipViews(APITenantTestCase):
@@ -537,8 +537,8 @@ class TestPartnershipViews(APITenantTestCase):
     def test_api_partners_list(self):
         response = self.forced_auth_req('get', '/api/v2/partners/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
         self.assertIn("Partner", response.data[0]["name"])
 
     @skip("Fix this")
@@ -556,7 +556,7 @@ class TestPartnershipViews(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @skip("different endpoint")
     def test_api_agreements_list(self):
@@ -564,8 +564,8 @@ class TestPartnershipViews(APITenantTestCase):
         response = self.forced_auth_req('get', '/api/partners/' + str(self.partner.id) +
                                         '/agreements/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
         self.assertIn("PCA", response.data[0]["agreement_type"])
 
     def test_api_staffmembers_list(self):
@@ -573,8 +573,8 @@ class TestPartnershipViews(APITenantTestCase):
                                         '/'.join(['/api/partners', str(self.partner.id), 'staff-members/']),
                                         user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
         self.assertIn("Jedi Master", response.data[0]["title"])
         self.assertIn("Mace", response.data[0]["first_name"])
         self.assertIn("Windu", response.data[0]["last_name"])
@@ -608,8 +608,8 @@ class TestPartnershipViews(APITenantTestCase):
                                             'sectors/'
                                         ]), user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
         self.assertIn("Sector", response.data[0]["sector_name"])
 
     @skip("skip v1 for now")
@@ -624,10 +624,10 @@ class TestPartnershipViews(APITenantTestCase):
                                             'budgets/'
                                         ]), user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
-        self.assertEquals(response.data[0]["unicef_cash"], 100)
-        self.assertEquals(response.data[0]["total"], 100)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["unicef_cash"], 100)
+        self.assertEqual(response.data[0]["total"], 100)
 
     @skip("different endpoint")
     def test_api_interventions_files_list(self):
@@ -641,7 +641,7 @@ class TestPartnershipViews(APITenantTestCase):
                                             'files/'
                                         ]), user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @skip("skip v1 for now")
     def test_api_interventions_amendments_list(self):
@@ -655,9 +655,9 @@ class TestPartnershipViews(APITenantTestCase):
                                             'amendments/'
                                         ]), user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
-        self.assertEquals(response.data[0]["type"], "Cost")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["type"], "Cost")
 
     @skip("skip v1 for now")
     def test_api_interventions_locations_list(self):
@@ -671,8 +671,8 @@ class TestPartnershipViews(APITenantTestCase):
                                             'locations/'
                                         ]), user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
         self.assertIn("Location", response.data[0]["location_name"])
 
 
@@ -759,12 +759,12 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Check for activity action created
-        self.assertEquals(model_stream(Agreement).count(), 1)
-        self.assertEquals(model_stream(Agreement)[0].verb, 'created')
-        self.assertEquals(model_stream(Agreement)[0].target.start, date(today.year - 1, 1, 1))
+        self.assertEqual(model_stream(Agreement).count(), 1)
+        self.assertEqual(model_stream(Agreement)[0].verb, 'created')
+        self.assertEqual(model_stream(Agreement)[0].target.start, date(today.year - 1, 1, 1))
 
     def test_agreements_create_max_signoff_single_date(self):
         today = datetime.date.today()
@@ -784,7 +784,7 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_agreements_create_max_signoff_no_date(self):
         today = datetime.date.today()
@@ -802,7 +802,7 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     def test_agreements_list(self):
         response = self.forced_auth_req(
@@ -811,8 +811,8 @@ class TestAgreementAPIView(APITenantTestCase):
             user=self.unicef_staff
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
         self.assertIn("Partner", response.data[0]["partner_name"])
 
     def test_agreements_update(self):
@@ -826,11 +826,11 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["status"], "active")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["status"], "active")
 
         # There should not be any activity stream item created as there is no delta data
-        self.assertEquals(model_stream(Agreement).count(), 0)
+        self.assertEqual(model_stream(Agreement).count(), 0)
 
     def test_agreements_retrieve(self):
         response = self.forced_auth_req(
@@ -839,8 +839,8 @@ class TestAgreementAPIView(APITenantTestCase):
             user=self.unicef_staff
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["agreement_number"], self.agreement.agreement_number)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["agreement_number"], self.agreement.agreement_number)
 
     def test_agreements_retrieve_staff_members(self):
         response = self.forced_auth_req(
@@ -849,8 +849,8 @@ class TestAgreementAPIView(APITenantTestCase):
             user=self.unicef_staff
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["authorized_officers"][0]["first_name"], self.partner_staff.first_name)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["authorized_officers"][0]["first_name"], self.partner_staff.first_name)
 
     def test_agreements_update_partner_staff(self):
         data = {
@@ -866,12 +866,12 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data["authorized_officers"]), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["authorized_officers"]), 2)
 
         # Check for activity action created
-        self.assertEquals(model_stream(Agreement).count(), 1)
-        self.assertEquals(model_stream(Agreement)[0].verb, 'changed')
+        self.assertEqual(model_stream(Agreement).count(), 1)
+        self.assertEqual(model_stream(Agreement)[0].verb, 'changed')
 
     def test_agreements_delete(self):
         response = self.forced_auth_req(
@@ -880,7 +880,7 @@ class TestAgreementAPIView(APITenantTestCase):
             user=self.partnership_manager_user
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_agreements_list_filter_type(self):
         params = {"agreement_type": "PCA"}
@@ -891,10 +891,10 @@ class TestAgreementAPIView(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
-        self.assertEquals(response.data[0]["id"], self.agreement.id)
-        self.assertEquals(response.data[0]["agreement_type"], "PCA")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.agreement.id)
+        self.assertEqual(response.data[0]["agreement_type"], "PCA")
 
     def test_agreements_list_filter_status(self):
         params = {"status": "active"}
@@ -905,10 +905,10 @@ class TestAgreementAPIView(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
-        self.assertEquals(response.data[0]["id"], self.agreement.id)
-        self.assertEquals(response.data[0]["status"], "active")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.agreement.id)
+        self.assertEqual(response.data[0]["status"], "active")
 
     def test_agreements_list_filter_partner_name(self):
         params = {"partner_name": self.partner.name}
@@ -919,9 +919,9 @@ class TestAgreementAPIView(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
-        self.assertEquals(self.partner.name, response.data[0]["partner_name"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
+        self.assertEqual(self.partner.name, response.data[0]["partner_name"])
 
     def test_agreements_list_filter_search(self):
         params = {"search": "Partner"}
@@ -932,8 +932,8 @@ class TestAgreementAPIView(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
         self.assertIn("Partner", response.data[0]["partner_name"])
 
     def test_agreements_list_filter_search_refno(self):
@@ -945,8 +945,8 @@ class TestAgreementAPIView(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
         # self.assertEquals(response.data[1]["agreement_number"], self.agreement.agreement_number)
 
     @skip("Test transitions - checked when going active")
@@ -967,8 +967,8 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data["errors"], ["Partner manager and signed by must be provided."])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["errors"], ["Partner manager and signed by must be provided."])
 
     def test_agreements_create_start_set_to_max_signed(self):
         today = datetime.date.today()
@@ -990,8 +990,8 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
             response.data["errors"],
             ["Start date must equal to the most recent signoff date (either signed_by_unicef_date or signed_by_partner_date)."])
 
@@ -1012,8 +1012,8 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data["errors"], ["Partner type must be CSO for PCA or SSFA agreement types."])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["errors"], ["Partner type must be CSO for PCA or SSFA agreement types."])
 
     @skip("Test transitions")
     def test_agreements_update_set_to_active_on_save(self):
@@ -1033,8 +1033,8 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["status"], Agreement.ACTIVE)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["status"], Agreement.ACTIVE)
 
     @skip("Test transitions")
     def test_partner_agreements_update_suspend(self):
@@ -1048,9 +1048,9 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["status"], "suspended")
-        self.assertEquals(Intervention.objects.get(agreement=self.agreement).status, "suspended")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["status"], "suspended")
+        self.assertEqual(Intervention.objects.get(agreement=self.agreement).status, "suspended")
 
     def test_partner_agreement_amendment_cp_cycle_end(self):
         amendment_type = AgreementAmendmentType.objects.create(
@@ -1058,7 +1058,7 @@ class TestAgreementAPIView(APITenantTestCase):
             type="CP extension"
         )
 
-        self.assertEquals(amendment_type.cp_cycle_end, CountryProgramme.current().to_date)
+        self.assertEqual(amendment_type.cp_cycle_end, CountryProgramme.current().to_date)
 
     @skip("signed amendment is now mandatory so we cannot delete?")
     def test_agreement_amendment_delete_valid(self):
@@ -1068,7 +1068,7 @@ class TestAgreementAPIView(APITenantTestCase):
             user=self.partnership_manager_user,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_agreement_amendment_delete_error(self):
         response = self.forced_auth_req(
@@ -1077,8 +1077,8 @@ class TestAgreementAPIView(APITenantTestCase):
             user=self.partnership_manager_user,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["Cannot delete a signed amendment"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["Cannot delete a signed amendment"])
 
     @skip("signed amendment is now mandatory so we cannot delete?")
     def test_agreement_amendment_type_delete_valid(self):
@@ -1088,7 +1088,7 @@ class TestAgreementAPIView(APITenantTestCase):
             user=self.partnership_manager_user,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_agreement_amendment_delete_error_signed(self):
         response = self.forced_auth_req(
@@ -1097,8 +1097,8 @@ class TestAgreementAPIView(APITenantTestCase):
             user=self.partnership_manager_user,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["Cannot delete an amendment type once amendment is signed"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["Cannot delete an amendment type once amendment is signed"])
 
 
 class TestPartnerStaffMemberAPIView(APITenantTestCase):
@@ -1120,9 +1120,9 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             user=self.unicef_staff
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn("Partner", response.data["name"])
-        self.assertEquals("Mace", response.data["staff_members"][0]["first_name"])
+        self.assertEqual("Mace", response.data["staff_members"][0]["first_name"])
 
     @skip("Skip staffmembers for now")
     def test_partner_staffmember_create_non_active(self):
@@ -1140,8 +1140,8 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data["non_field_errors"],
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["non_field_errors"],
                           ["New Staff Member needs to be active at the moment of creation"])
 
     @skip("Skip staffmembers for now")
@@ -1166,7 +1166,7 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn(
             "The Partner Staff member you are trying to add is associated with a different partnership",
             response.data["non_field_errors"][0])
@@ -1188,7 +1188,7 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
     @skip("Skip staffmembers for now")
     def test_partner_staffmember_retrieve(self):
@@ -1198,8 +1198,8 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             user=self.partner_staff_user
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["first_name"], "Mace")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["first_name"], "Mace")
 
     @skip("Skip staffmembers for now")
     def test_partner_staffmember_update(self):
@@ -1218,8 +1218,8 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["title"], "foobar updated")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["title"], "foobar updated")
 
     @skip("Skip staffmembers for now")
     def test_partner_staffmember_update_email(self):
@@ -1238,7 +1238,7 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertIn("User emails cannot be changed, please remove the user and add another one",
                       response.data["non_field_errors"][0])
 
@@ -1250,7 +1250,7 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             user=self.partner_staff_user
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     @skip("Skip staffmembers for now")
     def test_partner_staffmember_retrieve_properties(self):
@@ -1260,7 +1260,7 @@ class TestPartnerStaffMemberAPIView(APITenantTestCase):
             user=self.partner_staff_user
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class TestInterventionViews(APITenantTestCase):
@@ -1437,8 +1437,8 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
     def test_intervention_list_minimal(self):
         params = {"verbosity": "minimal"}
@@ -1449,8 +1449,8 @@ class TestInterventionViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data[0].keys(), ["id", "title"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0].keys(), ["id", "title"])
 
     def test_intervention_create(self):
         data = {
@@ -1468,11 +1468,11 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
             data=data
         )
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         # Check for activity action created
-        self.assertEquals(model_stream(Intervention).count(), 3)
-        self.assertEquals(model_stream(Intervention)[0].verb, 'created')
+        self.assertEqual(model_stream(Intervention).count(), 3)
+        self.assertEqual(model_stream(Intervention)[0].verb, 'created')
 
     def test_intervention_retrieve_fr_numbers(self):
         response = self.forced_auth_req(
@@ -1481,9 +1481,9 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["fr_numbers_details"]["12345"][0]["wbs"], "some_wbs")
-        self.assertEquals(response.data["fr_numbers_details"]["45678"][0]["wbs"], "some_wbs")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["fr_numbers_details"]["12345"][0]["wbs"], "some_wbs")
+        self.assertEqual(response.data["fr_numbers_details"]["45678"][0]["wbs"], "some_wbs")
 
     def test_intervention_active_update_population_focus(self):
         intervention_obj = Intervention.objects.get(id=self.intervention_data["id"])
@@ -1497,7 +1497,7 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
             data=self.intervention_data
         )
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_intervention_active_update_planned_budget(self):
         InterventionBudget.objects.filter(intervention=self.intervention_data.get("id")).delete()
@@ -1513,8 +1513,8 @@ class TestInterventionViews(APITenantTestCase):
             data=self.intervention_data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
             response.data,
             ["Planned budget is required if Intervention status is ACTIVE or IMPLEMENTED."])
 
@@ -1534,8 +1534,8 @@ class TestInterventionViews(APITenantTestCase):
             data=self.intervention_data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["Cannot change fields while intervention is active: unicef_cash"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["Cannot change fields while intervention is active: unicef_cash"])
 
     def test_intervention_active_update_sector_locations(self):
         intervention_obj = Intervention.objects.get(id=self.intervention_data["id"])
@@ -1551,8 +1551,8 @@ class TestInterventionViews(APITenantTestCase):
             data=self.intervention_data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
             response.data,
             ["Sector locations are required if Intervention status is ACTIVE or IMPLEMENTED."])
 
@@ -1564,8 +1564,8 @@ class TestInterventionViews(APITenantTestCase):
             data={}
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data,
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data,
                           {"document_type": ["This field is required."],
                            "agreement": ["This field is required."],
                               "title": ["This field is required."]})
@@ -1581,8 +1581,8 @@ class TestInterventionViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["Document type must be PD or SHPD in case of agreement is PCA."])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["Document type must be PD or SHPD in case of agreement is PCA."])
 
     def test_intervention_validation_doctype_ssfa(self):
         self.agreement.agreement_type = Agreement.SSFA
@@ -1597,8 +1597,8 @@ class TestInterventionViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["Document type must be SSFA in case of agreement is SSFA."])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["Document type must be SSFA in case of agreement is SSFA."])
 
     def test_intervention_validation_dates(self):
         today = datetime.date.today()
@@ -1613,8 +1613,8 @@ class TestInterventionViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ['Start date must precede end date'])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ['Start date must precede end date'])
 
     def test_intervention_update_planned_visits(self):
         import copy
@@ -1636,7 +1636,7 @@ class TestInterventionViews(APITenantTestCase):
             data=data,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_intervention_filter(self):
         # Test filter
@@ -1656,7 +1656,7 @@ class TestInterventionViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_intervention_filter_my_partnerships(self):
         # Test filter
@@ -1670,8 +1670,8 @@ class TestInterventionViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
 
     def test_intervention_planned_budget_delete(self):
         response = self.forced_auth_req(
@@ -1680,7 +1680,7 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_intervention_planned_budget_delete_invalid(self):
         intervention = Intervention.objects.get(id=self.intervention_data["id"])
@@ -1692,8 +1692,8 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["You do not have permissions to delete a planned budget"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["You do not have permissions to delete a planned budget"])
 
     def test_intervention_planned_visits_delete(self):
         response = self.forced_auth_req(
@@ -1702,7 +1702,7 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_intervention_planned_visits_delete_invalid(self):
         intervention = Intervention.objects.get(id=self.intervention_data["id"])
@@ -1714,8 +1714,8 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["You do not have permissions to delete a planned visit"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["You do not have permissions to delete a planned visit"])
 
     def test_intervention_attachments_delete(self):
         response = self.forced_auth_req(
@@ -1724,7 +1724,7 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_intervention_attachments_delete_invalid(self):
         intervention = Intervention.objects.get(id=self.intervention_data["id"])
@@ -1736,8 +1736,8 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["You do not have permissions to delete an attachment"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["You do not have permissions to delete an attachment"])
 
     def test_intervention_results_delete(self):
         response = self.forced_auth_req(
@@ -1746,7 +1746,7 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_intervention_results_delete_invalid(self):
         intervention = Intervention.objects.get(id=self.intervention_data["id"])
@@ -1758,8 +1758,8 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["You do not have permissions to delete a result"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["You do not have permissions to delete a result"])
 
     def test_intervention_amendments_delete(self):
         response = self.forced_auth_req(
@@ -1768,7 +1768,7 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_intervention_amendments_delete_invalid(self):
         intervention = Intervention.objects.get(id=self.intervention_data["id"])
@@ -1780,8 +1780,8 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["You do not have permissions to delete an amendment"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["You do not have permissions to delete an amendment"])
 
     def test_intervention_sector_locations_delete(self):
         response = self.forced_auth_req(
@@ -1790,7 +1790,7 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_204_NO_CONTENT)
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
 
     def test_intervention_sector_locations_delete_invalid(self):
         intervention = Intervention.objects.get(id=self.intervention_data["id"])
@@ -1802,8 +1802,8 @@ class TestInterventionViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ["You do not have permissions to delete a sector location"])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ["You do not have permissions to delete a sector location"])
 
 
     def test_api_interventions_values(self):
@@ -1815,9 +1815,9 @@ class TestInterventionViews(APITenantTestCase):
             data=params
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
-        self.assertEquals(response.data[0]["id"], self.intervention["id"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+        self.assertEqual(response.data[0]["id"], self.intervention["id"])
 
 
 class TestPartnershipDashboardView(APITenantTestCase):
@@ -1932,8 +1932,8 @@ class TestPartnershipDashboardView(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertNotEquals(response.data['active_value'], 0)
-        self.assertEquals(response.data['active_count'], 1)
-        self.assertEquals(response.data['active_this_year_count'], 1)
-        self.assertEquals(response.data['active_this_year_percentage'], '100%')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertNotEqual(response.data['active_value'], 0)
+        self.assertEqual(response.data['active_count'], 1)
+        self.assertEqual(response.data['active_this_year_count'], 1)
+        self.assertEqual(response.data['active_this_year_percentage'], '100%')

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -47,40 +47,40 @@ class TestReportViews(APITenantTestCase):
     def test_api_resultstructures_list(self):
         response = self.forced_auth_req('get', '/api/reports/result-structures/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_resulttypes_list(self):
         response = self.forced_auth_req('get', '/api/reports/result-types/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_sectors_list(self):
         response = self.forced_auth_req('get', '/api/reports/sectors/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_indicators_list(self):
         response = self.forced_auth_req('get', '/api/reports/indicators/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_results_list(self):
         response = self.forced_auth_req('get', '/api/reports/results/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(int(response.data[0]["id"]), self.result1.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data[0]["id"]), self.result1.id)
 
     def test_api_results_patch(self):
         url = '/api/reports/results/{}/'.format(self.result1.id)
         data = {"name": "patched name"}
         response = self.forced_auth_req('patch', url, user=self.unicef_staff, data=data)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["name"], "patched name")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], "patched name")
 
     def test_api_units_list(self):
         response = self.forced_auth_req('get', '/api/reports/units/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_apiv2_results_list(self):
         response = self.forced_auth_req(
@@ -89,8 +89,8 @@ class TestReportViews(APITenantTestCase):
             user=self.unicef_staff
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(int(response.data[0]["id"]), self.result1.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data[0]["id"]), self.result1.id)
 
     def test_apiv2_results_list_minimal(self):
         params = {"verbosity": "minimal"}
@@ -101,8 +101,8 @@ class TestReportViews(APITenantTestCase):
             data=params,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data[0].keys(), ["id", "name"])
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data[0].keys(), ["id", "name"])
 
     def test_apiv2_results_retrieve(self):
         response = self.forced_auth_req(
@@ -111,8 +111,8 @@ class TestReportViews(APITenantTestCase):
             user=self.unicef_staff
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(int(response.data["id"]), self.result1.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data["id"]), self.result1.id)
 
     def test_apiv2_results_list_current_cp(self):
         response = self.forced_auth_req(
@@ -121,8 +121,8 @@ class TestReportViews(APITenantTestCase):
             user=self.unicef_staff
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(int(response.data[0]["country_programme"]), CountryProgramme.current().id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data[0]["country_programme"]), CountryProgramme.current().id)
 
     def test_apiv2_results_list_filter_year(self):
         param = {
@@ -134,8 +134,8 @@ class TestReportViews(APITenantTestCase):
             user=self.unicef_staff,
             data=param,
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
     def test_apiv2_results_list_filter_cp(self):
         param = {
@@ -147,8 +147,8 @@ class TestReportViews(APITenantTestCase):
             user=self.unicef_staff,
             data=param,
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(int(response.data[0]["id"]), self.result1.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data[0]["id"]), self.result1.id)
 
     def test_apiv2_results_list_filter_result_type(self):
         param = {
@@ -160,8 +160,8 @@ class TestReportViews(APITenantTestCase):
             user=self.unicef_staff,
             data=param,
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(int(response.data[0]["id"]), self.result1.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data[0]["id"]), self.result1.id)
 
     def test_apiv2_results_list_filter_values(self):
         param = {
@@ -173,8 +173,8 @@ class TestReportViews(APITenantTestCase):
             user=self.unicef_staff,
             data=param,
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
     def test_apiv2_results_list_filter_values_bad(self):
         param = {
@@ -186,8 +186,8 @@ class TestReportViews(APITenantTestCase):
             user=self.unicef_staff,
             data=param,
         )
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, ['ID values must be integers'])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, ['ID values must be integers'])
 
     def test_apiv2_results_list_filter_combined(self):
         param = {
@@ -201,5 +201,5 @@ class TestReportViews(APITenantTestCase):
             data=param,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(int(response.data[0]["id"]), self.result1.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(int(response.data[0]["id"]), self.result1.id)

--- a/EquiTrack/t2f/tests/test_state_machine.py
+++ b/EquiTrack/t2f/tests/test_state_machine.py
@@ -260,7 +260,7 @@ class StateMachineTest(APITenantTestCase):
                                         data=response_json, user=self.traveler)
         response_json = json.loads(response.rendered_content)
         # Go straight to sent for payment when invoicing is disabled.
-        self.assertEquals(response_json['status'], Travel.SENT_FOR_PAYMENT)
+        self.assertEqual(response_json['status'], Travel.SENT_FOR_PAYMENT)
 
         # No email has been sent regarding SENT_FOR_PAYMENT status when invoicing is disabled.
         subjects = [x.subject for x in mail.outbox]

--- a/EquiTrack/trips/tests/test_views.py
+++ b/EquiTrack/trips/tests/test_views.py
@@ -31,13 +31,13 @@ class TestTripViews(APITenantTestCase):
 
         response = self.forced_auth_req('get', '/api/trips/')
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         # the length of this list should be 1
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(len(response.data), 1)
 
     def test_view_trips_api_action(self):
         # the trip should be in status planned
-        self.assertEquals(self.trip.status, Trip.PLANNED)
+        self.assertEqual(self.trip.status, Trip.PLANNED)
         response = self.forced_auth_req(
             'post',
             '/api/trips/{}/change-status/submitted/'.format(self.trip.id),
@@ -46,20 +46,20 @@ class TestTripViews(APITenantTestCase):
         # refresh trip from db
         self.trip.refresh_from_db()
         # trip should now have the status submitted
-        self.assertEquals(self.trip.status, Trip.SUBMITTED)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(self.trip.status, Trip.SUBMITTED)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     @skip('Not using trips anymore')
     def test_view_trip_action(self):
         response = self.forced_auth_req('get', '/trips/offices/')
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
     @skip('Not using trips anymore')
     def test_view_trips_dashboard(self):
         response = self.forced_auth_req('get', '/trips/')
 
-        self.assertEquals(response.status_code, 200)
+        self.assertEqual(response.status_code, 200)
 
 # TODO: Test all the rest of the views
 

--- a/EquiTrack/users/tests/test_views.py
+++ b/EquiTrack/users/tests/test_views.py
@@ -24,7 +24,7 @@ class TestSectionViews(APITenantTestCase):
             data={"values": "{},{}".format(s1.id, s2.id)}
         )
         # Returns empty set - figure out public schema testing
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class TestOfficeViews(APITenantTestCase):
@@ -41,7 +41,7 @@ class TestOfficeViews(APITenantTestCase):
             data={"values": "{},{}".format(o1.id, o2.id)}
         )
         # Returns empty set - figure out public schema testing
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
 
 class TestUserViews(APITenantTestCase):
@@ -56,8 +56,8 @@ class TestUserViews(APITenantTestCase):
     def test_api_users_list(self):
         response = self.forced_auth_req('get', '/api/users/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 3)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 3)
 
     def test_api_users_list_values(self):
         response = self.forced_auth_req(
@@ -66,8 +66,8 @@ class TestUserViews(APITenantTestCase):
             user=self.unicef_staff,
             data={"values": "{},{}".format(self.partnership_manager_user.id, self.unicef_superuser.id)}
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
 
     def test_api_users_list_values(self):
         response = self.forced_auth_req(
@@ -76,8 +76,8 @@ class TestUserViews(APITenantTestCase):
             user=self.unicef_staff,
             data={"values": "{},{}".format(self.partnership_manager_user.id, self.unicef_superuser.id)}
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
     def test_api_users_list_values_bad(self):
         response = self.forced_auth_req(
@@ -87,8 +87,8 @@ class TestUserViews(APITenantTestCase):
             data={"values": '1],2fg'}
         )
 
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
-        self.assertEquals(response.data, [u'Query parameter values are not integers'])
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data, [u'Query parameter values are not integers'])
 
     def test_api_users_list_managers(self):
         response = self.forced_auth_req(
@@ -98,13 +98,13 @@ class TestUserViews(APITenantTestCase):
             data={"partnership_managers": True}
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 1)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
 
     def test_api_groups_list(self):
         response = self.forced_auth_req('get', '/api/groups/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_users_retrieve_myprofile(self):
         response = self.forced_auth_req(
@@ -113,8 +113,8 @@ class TestUserViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["name"], self.unicef_staff.get_full_name())
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["name"], self.unicef_staff.get_full_name())
 
     @skip('no update method on view')
     def test_api_users_patch_myprofile(self):
@@ -129,9 +129,9 @@ class TestUserViews(APITenantTestCase):
             data=data
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["supervisor"], self.unicef_superuser.id)
-        self.assertEquals(response.data["oic"], self.unicef_superuser.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["supervisor"], self.unicef_superuser.id)
+        self.assertEqual(response.data["oic"], self.unicef_superuser.id)
 
         response = self.forced_auth_req(
             'get',
@@ -139,20 +139,20 @@ class TestUserViews(APITenantTestCase):
             user=self.unicef_staff,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(response.data["user"], self.unicef_staff.id)
-        self.assertEquals(response.data["supervisor"], self.unicef_superuser.id)
-        self.assertEquals(response.data["oic"], self.unicef_superuser.id)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["user"], self.unicef_staff.id)
+        self.assertEqual(response.data["supervisor"], self.unicef_superuser.id)
+        self.assertEqual(response.data["oic"], self.unicef_superuser.id)
 
     def test_api_offices_detail(self):
         response = self.forced_auth_req('get', '/api/offices/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_api_sections_detail(self):
         response = self.forced_auth_req('get', '/api/sections/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
     def test_minimal_verbosity(self):
         response = self.forced_auth_req('get', '/api/users/', data={'verbosity': 'minimal'}, user=self.unicef_superuser)


### PR DESCRIPTION
`assertEquals()` and `assertNotEquals()` were deprecated in Python 2.7.
https://docs.python.org/2/library/unittest.html#deprecated-aliases

This commit changes all instances of these two assertions to their
non-deprecated versions (`assertEqual()` and `assertNotEqual()`).

I used an automated tool to do this --
`find backend/EquiTrack -name "*.py"  | xargs  2to3 -w -n -f asserts`
