### PR TITLE
Removing unused requirement dateutils.

### DIFF
--- a/EquiTrack/requirements/base.txt
+++ b/EquiTrack/requirements/base.txt
@@ -65,7 +65,6 @@ html5lib==1.0b8 #must be added after xhtml2pdf
 reportlab==3.3.0
 flower==0.9.1
 easy-thumbnails==2.3
-dateutils==0.6.6
 django-debug-toolbar==1.6 # add debug-toolbar to be able to test in dev while we have the current docker build
 pyyaml==3.12
 


### PR DESCRIPTION
dateutils isn't referenced anywhere in the code that I can find. 

It's a small library that adds some utility functions over and above `python-dateutil`. 
