### PR TITLE
Add Flake8 testing to CI

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,0 @@
-[flake8]
-#max-line-length=120
-filename=*.py
-exclude=.git/*,migrations
-ignore=E501,T003,E126,E121

--- a/EquiTrack/.flake8
+++ b/EquiTrack/.flake8
@@ -1,0 +1,23 @@
+[flake8]
+max-line-length = 120
+exclude =
+    # don't worry about auto-generated code
+    migrations,
+    # Everything below here will eventually be removed from 'exclude'
+    activityinfo,
+    EquiTrack,
+    funds,
+    locations,
+    # manage_debug.py,
+    management,
+    notification,
+    partners,
+    publics,
+    reports,
+    supplies,
+    t2f,
+    tpm,
+    trips,
+    users,
+    vision,
+    workplan

--- a/EquiTrack/.flake8
+++ b/EquiTrack/.flake8
@@ -8,7 +8,7 @@ exclude =
     EquiTrack,
     funds,
     locations,
-    # manage_debug.py,
+    manage_debug.py,
     management,
     notification,
     partners,

--- a/EquiTrack/runtests.sh
+++ b/EquiTrack/runtests.sh
@@ -8,3 +8,6 @@ python manage.py makemigrations --dry-run | grep 'No changes detected' || (echo 
 coverage erase
 coverage run manage.py test --noinput --keepdb --settings=EquiTrack.settings.test "$@"
 coverage report
+
+# Check code style
+flake8 .

--- a/docs/guidelines.rst
+++ b/docs/guidelines.rst
@@ -19,8 +19,6 @@ Flake8 exceptions
 
 We allow the following flake8 "rules" to be violated:
 
-* E121 and E126: These rules specify the proper amount of "hanging indent" for multi-line
-  statements. We allow them to be violated.
 * max-line-length: The default maximum is 80 characters, which we have increased to 120 characters.
   Allowing unlimited line lengths makes PRs difficult to review in the Github interface.
 


### PR DESCRIPTION
This just adds the ability for flake8 to run on CircleCI (and locally). I expect this build to fail and then I'll update .flake8 to make sure it passes.

I've removed our exclusion of E121 and E126 from the guidelines because apparently there is currently no code violating those rules. Here is the current list of violations (by code type):

```
$ flake8 --statistics --count -qq
47    E111 indentation is not a multiple of four
10    E122 continuation line missing indentation or outdented
39    E127 continuation line over-indented for visual indent
35    E128 continuation line under-indented for visual indent
7     E201 whitespace after '{'
5     E202 whitespace before '}'
1     E203 whitespace before ':'
1     E225 missing whitespace around operator
15    E231 missing whitespace after ':'
9     E261 at least two spaces before inline comment
3     E262 inline comment should start with '# '
31    E265 block comment should start with '# '
42    E266 too many leading '#' for block comment
4     E301 expected 1 blank line, found 0
44    E302 expected 2 blank lines, found 1
20    E303 too many blank lines (3)
5     E305 expected 2 blank lines after class or function definition, found 1
6     E306 expected 1 blank line before a nested definition, found 0
20    E402 module level import not at top of file
557   E501 line too long (154 > 120 characters)
1     E703 statement ends with a semicolon
1     E712 comparison to False should be 'if cond is False:' or 'if not cond:'
1     E731 do not assign a lambda expression, use a def
108   F401 '.celery.app as celery_app' imported but unused
4     F403 'from local_base import *' used; unable to detect undefined names
35    F405 'INSTALLED_APPS' may be undefined, or defined from star imports: local_base
5     F811 redefinition of unused 'WorkplanProject' from line 6
5     F821 undefined name 'PCALocation'
29    F841 local variable 'exp' is assigned to but never used
7     N802 function name should be lowercase
1     N803 argument name should be lowercase
13    N806 variable in function should be lowercase
1     W291 trailing whitespace
12    W292 no newline at end of file
3     W293 blank line contains whitespace
12    W391 blank line at end of file
1139
```