### PR TITLE
Replace 3rd party library django-hstore

### DIFF
--- a/EquiTrack/EquiTrack/settings/base.py
+++ b/EquiTrack/EquiTrack/settings/base.py
@@ -398,7 +398,6 @@ SHARED_APPS = (
     'analytical',
     'mptt',
     'easy_pdf',
-    'django_hstore',
 
     'vision',
     'management',

--- a/EquiTrack/partners/migrations/0001_initial.py
+++ b/EquiTrack/partners/migrations/0001_initial.py
@@ -5,10 +5,10 @@ from __future__ import unicode_literals
 import EquiTrack.mixins
 from django.conf import settings
 import django.contrib.postgres.fields.jsonb
+from django.contrib.postgres.fields import HStoreField
 from django.db import migrations, models
 import django.db.models.deletion
 import django.utils.timezone
-import django_hstore.fields
 import model_utils.fields
 import partners.models
 import smart_selects.db_fields
@@ -187,7 +187,7 @@ class Migration(migrations.Migration):
                 ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
                 ('year', models.CharField(max_length=4)),
                 ('planned_amount', models.IntegerField(default=0, verbose_name=b'Planned Cash Transfers')),
-                ('activities', django_hstore.fields.DictionaryField(blank=True, null=True)),
+                ('activities', HStoreField(blank=True, null=True)),
                 ('planned_visits', models.IntegerField(default=0)),
                 ('activities_list', models.ManyToManyField(blank=True, related_name='activities_list', to='reports.Result')),
                 ('intervention', models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, related_name='results', to='partners.GovernmentIntervention')),

--- a/EquiTrack/requirements/base.txt
+++ b/EquiTrack/requirements/base.txt
@@ -9,7 +9,6 @@ django-logentry-admin==1.0.2
 djrill==2.1.0
 django-autocomplete-light==3.2.1
 django-smart-selects==1.3.1
-django-hstore==1.4.2
 django-redis-cache==1.7.1
 django-datetime-widget==0.9.3
 django-leaflet==0.19.0


### PR DESCRIPTION
Replace 3rd party library `django-hstore` with native Django functionality. (hstore has been native since django 1.8)

Removing this library removes an impediment to upgrading to Django 1.10. django-hstore isn't compatible with Django 1.10. The author is aware of this but has no more time to maintain the module and is looking for a new  maintainer.
https://github.com/djangonauts/django-hstore/issues/154
https://github.com/djangonauts/django-hstore/issues/161

Also tidied imports and fixed all flake8 complaints in the file I touched (`partners/models.py`).
