### PR TITLE
Add assertions to several of the test_urls() methods in t2f test cases

### DIFF
--- a/EquiTrack/t2f/tests/test_action_points.py
+++ b/EquiTrack/t2f/tests/test_action_points.py
@@ -30,11 +30,19 @@ class ActionPoints(APITenantTestCase):
         mail.outbox = []
 
     def test_urls(self):
-        list_url = reverse('t2f:action_points:list')
-        self.assertEqual(list_url, '/api/t2f/action_points/')
+        '''Verify URL pattern names generate the URLs we expect them to.'''
+        # names_and_paths contains 3-tuples of (URL pattern name, variable URL portion, kwargs)
+        names_and_paths = (
+            ('list', '', {}),
+            ('details', '1/', {'action_point_pk': 1}),
+            ('dashboard', 'dashboard/', {}),
+            ('export', 'export/', {}),
+            )
 
-        details_url = reverse('t2f:action_points:details', kwargs={'action_point_pk': 1})
-        self.assertEqual(details_url, '/api/t2f/action_points/1/')
+        for name, url_part, kwargs in names_and_paths:
+            actual_url = reverse('t2f:action_points:' + name, kwargs=kwargs)
+            expected_url = '/api/t2f/action_points/' + url_part
+            self.assertEqual(actual_url, expected_url)
 
     def test_list_view(self):
         with self.assertNumQueries(6):

--- a/EquiTrack/t2f/tests/test_static_data_endpoint.py
+++ b/EquiTrack/t2f/tests/test_static_data_endpoint.py
@@ -2,6 +2,8 @@ from __future__ import unicode_literals
 
 import json
 
+from django.core.urlresolvers import reverse
+
 from EquiTrack.factories import UserFactory
 from EquiTrack.tests.mixins import APITenantTestCase
 
@@ -11,6 +13,10 @@ class StaticDataEndpointTest(APITenantTestCase):
     def setUp(self):
         super(StaticDataEndpointTest, self).setUp()
         self.unicef_staff = UserFactory(is_staff=True)
+
+    def test_urls(self):
+        '''Verify URL pattern names generate the URLs we expect them to.'''
+        self.assertEqual(reverse('t2f:static_data'), '/api/t2f/static_data/')
 
     def test_static_data_endpoint(self):
         response = self.forced_auth_req('get', '/api/t2f/static_data/', user=self.unicef_staff)

--- a/EquiTrack/t2f/tests/test_travel_details.py
+++ b/EquiTrack/t2f/tests/test_travel_details.py
@@ -29,21 +29,31 @@ class TravelDetails(APITenantTestCase):
                                     supervisor=self.unicef_staff)
 
     def test_urls(self):
-        details_url = reverse('t2f:travels:details:index', kwargs={'travel_pk': 1})
-        self.assertEqual(details_url, '/api/t2f/travels/1/')
+        '''Verify URL pattern names generate the URLs we expect them to.'''
+        # names_and_paths contains 3-tuples of (URL pattern name, variable URL portion, kwargs)
+        COMMON_KWARGS = {'travel_pk': 1}
+        names_and_paths = (
+            ('index', '', COMMON_KWARGS),
+            ('attachments', 'attachments/', COMMON_KWARGS),
+            ('attachment_details', 'attachments/1/', {'travel_pk': 1, 'attachment_pk': 1}),
+            ('clone_for_driver', 'add_driver/', COMMON_KWARGS),
+            ('clone_for_secondary_traveler', 'duplicate_travel/', COMMON_KWARGS),
+            )
+        for name, url_part, kwargs in names_and_paths:
+            actual_url = reverse('t2f:travels:details:' + name, kwargs=kwargs)
+            expected_url = '/api/t2f/travels/1/' + url_part
+            self.assertEqual(actual_url, expected_url)
 
-        attachments_url = reverse('t2f:travels:details:attachments', kwargs={'travel_pk': 1})
-        self.assertEqual(attachments_url, '/api/t2f/travels/1/attachments/')
-
-        attachment_details_url = reverse('t2f:travels:details:attachment_details',
-                                         kwargs={'travel_pk': 1, 'attachment_pk': 1})
-        self.assertEqual(attachment_details_url, '/api/t2f/travels/1/attachments/1/')
-
-        add_driver_url = reverse('t2f:travels:details:clone_for_driver', kwargs={'travel_pk': 1})
-        self.assertEqual(add_driver_url, '/api/t2f/travels/1/add_driver/')
-
-        duplicate_travel_url = reverse('t2f:travels:details:clone_for_secondary_traveler', kwargs={'travel_pk': 1})
-        self.assertEqual(duplicate_travel_url, '/api/t2f/travels/1/duplicate_travel/')
+        # Verify the many state change URLs.
+        names = ('submit_for_approval', 'approve', 'reject', 'cancel', 'plan', 'send_for_payment',
+                 'submit_certificate', 'approve_certificate', 'reject_certificate', 'mark_as_certified',
+                 'mark_as_completed',)
+        kwargs = {'travel_pk': 1, 'transition_name': None}
+        for name in names:
+            kwargs['transition_name'] = name
+            actual_url = reverse('t2f:travels:details:state_change', kwargs=kwargs)
+            expected_url = '/api/t2f/travels/1/{}/'.format(name)
+            self.assertEqual(actual_url, expected_url)
 
     def test_details_view(self):
         with self.assertNumQueries(25):
@@ -498,8 +508,8 @@ class TravelDetails(APITenantTestCase):
         travel_id = response_json['id']
 
         response = self.forced_auth_req('post', reverse('t2f:travels:details:state_change',
-                                                         kwargs={'travel_pk': travel_id,
-                                                                 'transition_name': 'submit_for_approval'}),
+                                                        kwargs={'travel_pk': travel_id,
+                                                                'transition_name': 'submit_for_approval'}),
                                         data=data, user=self.unicef_staff)
         response_json = json.loads(response.rendered_content)
         self.assertEqual(response_json, {'non_field_errors': ['All itinerary items has to have DSA region assigned']})
@@ -533,8 +543,8 @@ class TravelDetails(APITenantTestCase):
         travel_id = response_json['id']
 
         response = self.forced_auth_req('post', reverse('t2f:travels:details:state_change',
-                                                         kwargs={'travel_pk': travel_id,
-                                                                 'transition_name': 'submit_for_approval'}),
+                                                        kwargs={'travel_pk': travel_id,
+                                                                'transition_name': 'submit_for_approval'}),
                                         data=data, user=self.unicef_staff)
         self.assertEqual(response.status_code, 200)
 
@@ -643,8 +653,7 @@ class TravelDetails(APITenantTestCase):
         response = self.forced_auth_req('post', reverse('t2f:travels:list:index'),
                                         data=data, user=self.unicef_staff)
         response_json = json.loads(response.rendered_content)
-        itinerary_origin_destination_expectation = [u'Origin should match with'
-                                                     ' the previous destination',]
+        itinerary_origin_destination_expectation = [u'Origin should match with the previous destination']
         self.assertEqual(response_json['itinerary'], itinerary_origin_destination_expectation)
 
     def test_ta_not_required(self):

--- a/EquiTrack/t2f/tests/test_vision_export.py
+++ b/EquiTrack/t2f/tests/test_vision_export.py
@@ -36,6 +36,11 @@ class VisionXML(APITenantTestCase):
         country.business_area_code = '0060'
         country.save()
 
+    def test_urls(self):
+        '''Verify URL pattern names generate the URLs we expect them to.'''
+        self.assertEqual(reverse('t2f:vision_invoice_export'), '/api/t2f/vision_invoice_export/')
+        self.assertEqual(reverse('t2f:vision_invoice_update'), '/api/t2f/vision_invoice_update/')
+
     def make_invoice_updater(self, status=Invoice.SUCCESS):
         root = ET.Element('ta_invoice_acks')
         for invoice in Invoice.objects.filter(status__in=[Invoice.PROCESSING, Invoice.PENDING]):
@@ -133,10 +138,10 @@ class VisionXML(APITenantTestCase):
 
         # Update invoices like vision would do it
         response = self.forced_auth_req('post', reverse('t2f:vision_invoice_update'),
-                             data=updater_xml_structure,
-                             user=self.unicef_staff,
-                             request_format=None,
-                             content_type='text/xml')
+                                        data=updater_xml_structure,
+                                        user=self.unicef_staff,
+                                        request_format=None,
+                                        content_type='text/xml')
         self.assertEqual(response.status_code, 200)
 
     def test_personal_number_usage(self):


### PR DESCRIPTION
Add assertions to several of the `test_urls()` methods in t2f test cases and refactor existing ones to make them more declarative in style (to minimize repetition of invariant pieces). This PR lays the groundwork for another PR I have in the pipeline to refactor many urls.py files for Django 1.10 compatibility. Also fixed all flake8 complaints in all files I touched.

**I have 2 questions.**

There was one URL I couldn't figure out where to test. **Where should I test this URL, or should I just skip it?**
`url(r'^invoice_calculations/(?P<travel_pk>[0-9]+)/$', TravelEditView.as_view(), name='invedit')`

Also, in `t2f/urls.py`, `action_points_patterns` contains this -- 
`url(r'^dashboard/', action_points_dashboard_list, name='dashboard')`

The URL regex doesn't include a '$' at the end, so while this works --
`resolve('/api/t2f/action_points/dashboard/')`
This also works, which maybe shouldn't be the case -- 
`resolve('/api/t2f/action_points/dashboard/sdfasdfsd')`

**I'm happy to fix that as part of this PR, just let me know if I should.**
