### PR TITLE
Fix bug where interventions would not transition properly due to errant query

### DIFF
--- a/EquiTrack/partners/tasks.py
+++ b/EquiTrack/partners/tasks.py
@@ -85,7 +85,7 @@ def intervention_status_automatic_transition(admin=None, workspace=None, **kwarg
         # compiling a list of them to send to an admin or save somewhere in the future
         bad_interventions = []
 
-        active_ended = Intervention.objects.filter(status__in=Intervention.ACTIVE,
+        active_ended = Intervention.objects.filter(status=Intervention.ACTIVE,
                                                    end=datetime.date.today() - datetime.timedelta(days=1))
 
         # get all the interventions for which their status is endend and total otustanding_amt is 0 and

--- a/EquiTrack/partners/tasks.py
+++ b/EquiTrack/partners/tasks.py
@@ -29,6 +29,7 @@ def get_intervention_context(i):
 
 def task_decorator(funct):
     admin = User.objects.get(username=settings.TASK_ADMIN_USER)
+
     def wrapper(*args, **kwargs):
         for c in Country.objects.exclude(name='Global').all():
             connection.set_tenant(c)
@@ -120,7 +121,6 @@ def intervention_status_automatic_transition(admin=None, workspace=None, **kwarg
         logger.info("Transitioned interventions {} ".format(processed))
 
 
-
 @task_decorator
 @app.task
 def intervention_notification_signed_no_frs(admin=None, workspace=None, **kwargs):
@@ -191,5 +191,3 @@ def intervention_notification_ending(admin=None, workspace=None, **kwargs):
                 template_data=email_context
             )
             notification.send_notification()
-
-


### PR DESCRIPTION
Some transitions would not transition properly due to errant query. I found this problem while writing a test for this code (which will appear in a future PR).

Problematic code was this --
```
Intervention.objects.filter(status__in=Intervention.ACTIVE)
```

`Intervention.ACTIVE == 'active'`, so the code above is equivalent to this --
```
Intervention.objects.filter(status__in=[‘a’, ‘c’, ’t’, ‘i’, ‘v’, ‘e’])
```

This code was originally correct but was changed to the incorrect version two weeks ago in https://github.com/unicef/etools/commit/447dae24684806eddd6c10293e6ccef30a921926