### PR TITLE
Cleanup workplan app

### DIFF
--- a/EquiTrack/.flake8
+++ b/EquiTrack/.flake8
@@ -13,4 +13,3 @@ exclude =
     t2f,
     tpm,
     vision,
-    workplan

--- a/EquiTrack/workplan/models.py
+++ b/EquiTrack/workplan/models.py
@@ -90,10 +90,10 @@ class ResultWorkplanProperty(models.Model):
     result = models.ForeignKey(Result, related_name='workplan_properties')
     assumptions = models.TextField(null=True, blank=True)
     STATUS = (
-        ("On Track","On Track"),
-        ("Constrained","Constrained"),
-        ("No Progress","No Progress"),
-        ("Target Met","Target Met"),
+        ("On Track", "On Track"),
+        ("Constrained", "Constrained"),
+        ("No Progress", "No Progress"),
+        ("Target Met", "Target Met"),
     )
     status = models.CharField(max_length=255, null=True, blank=True, choices=STATUS)
     prioritized = models.BooleanField(default=False)
@@ -142,6 +142,7 @@ class Milestone(models.Model):
     result_wp_property = models.ForeignKey(ResultWorkplanProperty, related_name="milestones")
     description = models.TextField()
     assumptions = models.TextField(null=True, blank=True)
+
 
 class CoverPage(models.Model):
     """

--- a/EquiTrack/workplan/serializers.py
+++ b/EquiTrack/workplan/serializers.py
@@ -85,8 +85,8 @@ class CoverPageSerializer(serializers.ModelSerializer):
 
     class Meta:
         model = CoverPage
-        fields = ('id', 'workplan_project', 'national_priority', 'responsible_government_entity', 'planning_assumptions',
-                  'budgets', 'logo')
+        fields = ('id', 'workplan_project', 'national_priority', 'responsible_government_entity',
+                  'planning_assumptions', 'budgets', 'logo')
 
 
 class WorkplanProjectSerializer(serializers.ModelSerializer):

--- a/EquiTrack/workplan/tasks.py
+++ b/EquiTrack/workplan/tasks.py
@@ -2,7 +2,7 @@ from django.core import mail
 from django.contrib.auth.models import User
 
 from EquiTrack.celery import app
-from .models import Comment
+from workplan.models import Comment
 
 
 @app.task

--- a/EquiTrack/workplan/views.py
+++ b/EquiTrack/workplan/views.py
@@ -2,10 +2,10 @@ from rest_framework import mixins, viewsets, status
 from rest_framework.response import Response
 from rest_framework.permissions import IsAdminUser
 
-from .models import Workplan, Comment, ResultWorkplanProperty, WorkplanProject, Label, Milestone
-from .serializers import CommentSerializer, WorkplanSerializer,\
+from workplan.models import Workplan, Comment, ResultWorkplanProperty, WorkplanProject, Label, Milestone
+from workplan.serializers import CommentSerializer, WorkplanSerializer,\
     WorkplanProjectSerializer, LabelSerializer, MilestoneSerializer
-from .tasks import notify_comment_tagged_users
+from workplan.tasks import notify_comment_tagged_users
 
 
 class TaggedNotificationMixin(object):
@@ -55,10 +55,10 @@ class WorkplanViewSet(viewsets.ModelViewSet):
 
 
 class LabelViewSet(mixins.RetrieveModelMixin,
-                      mixins.ListModelMixin,
-                      mixins.CreateModelMixin,
-                      mixins.DestroyModelMixin,
-                      viewsets.GenericViewSet):
+                   mixins.ListModelMixin,
+                   mixins.CreateModelMixin,
+                   mixins.DestroyModelMixin,
+                   viewsets.GenericViewSet):
     queryset = Label.objects.all()
     serializer_class = LabelSerializer
     permission_classes = (IsAdminUser,)


### PR DESCRIPTION
Fixes flake8 violations.

Issues for later:
* Don't refer directly to User model
* models.py: Address TODOs
* models.py: Make TextFields not null
* views.py: Address TODOs
* views.py: Remove TaggedNotificationMixin (not used)
* test_views.py: docstrings
* test_views.py: use URL reversal
* test_views.py: remove commented code
* add tests
