### PR TITLE
Quieter audit tests

### DIFF
--- a/EquiTrack/EquiTrack/settings/local.py
+++ b/EquiTrack/EquiTrack/settings/local.py
@@ -1,4 +1,5 @@
 import datetime
+import logging
 import sys
 
 from EquiTrack.settings.base import *  # noqa
@@ -77,6 +78,9 @@ if 'test' in sys.argv:
         'utils.common',
         'utils.writable_serializers',
     ]
+
+    # Disable logging output during tests
+    logging.disable(logging.CRITICAL)
 else:
     # Settings which should NOT be active during automated tests
 

--- a/EquiTrack/audit/tests/test_transitions.py
+++ b/EquiTrack/audit/tests/test_transitions.py
@@ -1,20 +1,17 @@
 import random
 
-from django.core.management import call_command
 from factory import fuzzy
 from rest_framework import status
 
 from EquiTrack.tests.mixins import APITenantTestCase
 from audit.transitions.conditions import EngagementSubmitReportRequiredFieldsCheck, SPSubmitReportRequiredFieldsCheck, \
     AuditSubmitReportRequiredFieldsCheck
-from .base import EngagementTransitionsTestCaseMixin
-from .factories import MicroAssessmentFactory, AuditFactory, SpotCheckFactory
+from audit.tests.base import EngagementTransitionsTestCaseMixin
+from audit.tests.factories import MicroAssessmentFactory, AuditFactory, SpotCheckFactory
 
 
 class EngagementCheckTransitionsTestCaseMixin(object):
-    def setUp(self):
-        call_command('loaddata', 'audit_risks_blueprints')
-        super(EngagementCheckTransitionsTestCaseMixin, self).setUp()
+    fixtures = ('audit_risks_blueprints', )
 
     def _test_transition(self, user, action, expected_response, errors=None, data=None):
         response = self.forced_auth_req(

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -945,8 +945,6 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
 
-        print response.data
-
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data["authorized_officers"]), 2)
 


### PR DESCRIPTION
This...

1) removes extraneous output from our test output, and
2) makes things about 4 seconds faster because the fixture is loaded once per class, instead of per-testcase.