### PR TITLE
Modernize exception message syntax 

### DIFF
--- a/EquiTrack/EquiTrack/tests/test_validation_mixins.py
+++ b/EquiTrack/EquiTrack/tests/test_validation_mixins.py
@@ -1,0 +1,66 @@
+# Python imports
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+# Don't enable unicode_literals in this module until Python 3. Tests in this module rely on being able to create
+# both str and unicode literals.
+# from __future__ import unicode_literals
+from unittest import TestCase
+
+from EquiTrack.validation_mixins import (
+    _BaseStateError,
+    BasicValidationError,
+    StateValidError,
+    TransitionError,
+    )
+
+
+class TestExceptions(TestCase):
+    '''Tests behavior of the 3 exceptions defined in validation_mixins. StateValidError and TransitionError are
+    tested through their base class _BaseStateError.
+    '''
+    def test_basic_validation_error(self):
+        '''Exercise converting BasicValidationError to string'''
+        e = BasicValidationError()
+        self.assertEqual(str(e), '')
+
+        e = BasicValidationError('hello world')
+        self.assertEqual(str(e), 'hello world')
+
+        # The param goes in as unicode, comes out as str.
+        e = BasicValidationError(u'hello world')
+        self.assertEqual(str(e), 'hello world')
+
+    def test_state_valid_error(self):
+        '''Ensure StateValidError inherits from _BaseStateError'''
+        self.assertIsInstance(StateValidError(), _BaseStateError)
+
+    def test_transition_valid_error(self):
+        '''Ensure TransitionError inherits from _BaseStateError'''
+        self.assertIsInstance(TransitionError(), _BaseStateError)
+
+    def test_base_state_error_stringification(self):
+        '''Exercise converting _BaseStateError to a string'''
+        e = _BaseStateError()
+        self.assertEqual(str(e), '')
+
+        e = _BaseStateError(['hello world'])
+        self.assertEqual(str(e), 'hello world')
+
+        # Test mix of str and unicode in the params
+        e = _BaseStateError(['hello world', u'goodbye world'])
+        self.assertEqual(str(e), 'hello world\ngoodbye world')
+
+        # Test mix of str and non-ASCII unicode in the params
+        e = _BaseStateError(['hello world', 'goodbye world', u'l\xf6rem ipsum', u'l\xf6rem ipsum'.encode('utf-8')])
+        self.assertEqual(str(e), u'hello world\ngoodbye world\nl\xf6rem ipsum\nl\xf6rem ipsum'.encode('utf-8'))
+
+    def test_base_state_error_creation(self):
+        '''Exercise _BaseStateError creation. _BaseStateError accepts only one param, and it must be a list.'''
+        for param in ('hello world',
+                      ('hello world', 'goodbye world'),
+                      42,
+                      object(),
+                      TestCase,):
+            with self.assertRaises(TypeError):
+                _BaseStateError(param)

--- a/EquiTrack/EquiTrack/validation_mixins.py
+++ b/EquiTrack/EquiTrack/validation_mixins.py
@@ -19,6 +19,7 @@ from EquiTrack.stream_feed.actions import create_snapshot_activity_stream
 from EquiTrack.parsers import parse_multipart_data
 from utils.common.utils import get_all_field_names
 
+
 def check_editable_fields(obj, fields):
     if not getattr(obj, 'old_instance', None):
         return False, fields
@@ -50,6 +51,7 @@ def check_required_fields(obj, fields):
         return False, error_fields
     return True, None
 
+
 def field_comparison(f1, f2):
     if isinstance(f1, FieldFile):
         new_file = getattr(f1, 'name', None)
@@ -59,6 +61,7 @@ def field_comparison(f1, f2):
     elif f1 != f2:
         return False
     return True
+
 
 def check_rigid_related(obj, related):
     current_related = list(getattr(obj, related).filter())
@@ -293,15 +296,19 @@ class _BaseStateError(BaseException):
         # and str instances, so we have to combine them carefully to avoid encode/decode errors.
         return u'\n'.join([_unicode_if(msg) for msg in self.args[0]])
 
+
 class TransitionError(_BaseStateError):
     pass
+
 
 class StateValidError(_BaseStateError):
     pass
 
+
 class BasicValidationError(BaseException):
     def __init__(self, message=''):
         super(BasicValidationError, self).__init__(message)
+
 
 def error_string(function):
     def wrapper(*args, **kwargs):
@@ -330,6 +337,7 @@ def transition_error_string(function):
             return (False, ['generic_transition_fail'])
     return wrapper
 
+
 def state_error_string(function):
     def wrapper(*args, **kwargs):
         try:
@@ -343,12 +351,15 @@ def state_error_string(function):
             return (False, ['generic_state_validation_fail'])
     return wrapper
 
+
 def update_object(obj, kwdict):
     for k, v in kwdict.iteritems():
         setattr(obj, k, v)
 
+
 class CompleteValidation(object):
     PERMISSIONS_CLASS = None
+
     def __init__(self, new, user=None, old=None, instance_class=None, stateless=False, disable_rigid_check=False):
         if old and isinstance(old, dict):
             raise TypeError('if old is transmitted to complete validation it needs to be a model instance')
@@ -394,8 +405,8 @@ class CompleteValidation(object):
             self.old_status = self.old.status if self.old else None
         self.user = user
 
-        # permissions to be set in each function that is needed, this attribute can change values as auto-update goes through
-        # different statuses
+        # permissions to be set in each function that is needed, this attribute can change values as auto-update goes
+        # through different statuses
         self.permissions = None
         self.disable_rigid_check = disable_rigid_check
 
@@ -431,7 +442,6 @@ class CompleteValidation(object):
         # set old instance on instance to make it available to the validation functions
         setattr(self.new, 'old_instance', self.old)
         self.permissions = self.get_permissions(self.new)
-
 
         # check conditions and permissions
         conditions_check = self.check_transition_conditions(self.transition)
@@ -494,16 +504,15 @@ class CompleteValidation(object):
 
         for potential_transition_to in pttl:
             # test to see if it's a viable transition:
-            # logging.debug("test to see if transition is possible : {} -> {}".format(self.new.status, potential_transition_to))
+            # template = "test to see if transition is possible : {} -> {}"
+            # logging.debug(template.format(self.new.status, potential_transition_to))
             # try to find a possible transition... if no possible transition (transition was not defined on the model
             # it will always validate
             possible_fsm_transition = self._get_fsm_defined_transitions(self.new.status, potential_transition_to)
             if not possible_fsm_transition:
-                logging.debug("transition: {} -> {} is possible since there was no transition defined on the model".format(
-                    self.new.status, potential_transition_to
-                ))
+                template = "transition: {} -> {} is possible since there was no transition defined on the model"
+                logging.debug(template.format(self.new.status, potential_transition_to))
             if self.auto_transition_validation(possible_fsm_transition)[0]:
-
                 # get the side effects function if any
                 SIDE_EFFECTS_DICT = getattr(self.new.__class__, 'TRANSITION_SIDE_EFFECTS', {})
                 transition_side_effects = SIDE_EFFECTS_DICT.get(potential_transition_to, [])
@@ -549,7 +558,8 @@ class CompleteValidation(object):
         while self._make_auto_transition():
             any_transition_made = True
 
-        # logging.debug("*************** ENDING AUTO TRANSITIONS ***************** auto_transitioned: {}".format(any_transition_made))
+        # template = "*************** ENDING AUTO TRANSITIONS ***************** auto_transitioned: {}"
+        # logging.debug(template.format(any_transition_made))
 
         # reset rigid check:
         self.disable_rigid_check = originial_rigid_check_setting
@@ -602,7 +612,8 @@ class CompleteValidation(object):
 
             # before checking if any further transitions can be made, if the current instance just transitioned,
             # apply side-effects:
-            # TODO.. this needs to be re-written and have a consistent way to include side-effects on both auto-transition / manual transition
+            # TODO.. this needs to be re-written and have a consistent way to include side-effects on both
+            # auto-transition / manual transition
             self._apply_current_side_effects()
 
             if self.make_auto_transitions():

--- a/EquiTrack/t2f/views/__init__.py
+++ b/EquiTrack/t2f/views/__init__.py
@@ -37,6 +37,6 @@ def run_transition(serializer):
         transition = getattr(instance, transition_name)
         try:
             transition()
-        except (TransitionNotAllowed, TransitionError) as exc:
-            raise ValidationError({'non_field_errors': [exc.message]})
+        except (TransitionNotAllowed, TransitionError) as exception:
+            raise ValidationError({'non_field_errors': [str(exception)]})
         instance.save()

--- a/EquiTrack/utils/permissions/tests/test_permission_serializers.py
+++ b/EquiTrack/utils/permissions/tests/test_permission_serializers.py
@@ -106,7 +106,7 @@ class PermissionsBasedSerializerTestCase(TestCase):
         serializer.is_valid(raise_exception=True)
         with self.assertRaises(IntegrityError) as cm:
             serializer.save()
-        self.assertIn('null value in column "field" violates not-null constraint', cm.exception.message)
+        self.assertIn('null value in column "field" violates not-null constraint', str(cm.exception))
 
     def test_updating(self):
         serializer = self.ParentSerializer(self.parent, context={'user': self.user1}, data={


### PR DESCRIPTION
Three pieces of code in eTools use deprecated Python syntax that raises this when warnings are enabled --
```
DeprecationWarning: BaseException.message has been deprecated as of Python 2.6
```

See second bullet here --
https://docs.python.org/2/whatsnew/2.6.html#deprecations-and-removals

This PR updates the code that uses the deprecated syntax.

I ended up refactoring the definition of some of the custom exceptions in `validation_mixins.py`, so I added a test case for them.

Bonus fixes in `validation_mixins.py` (898595ba56741b9c932338b83352872afb83dc41) -- 
 * Fixed a bug in `transition_error_string()` and `state_error_string()`. In the case where each accessed `e.message`, they returned a 2-tuple of `(bool, string)`. In all other cases, the return is a 2-tuple of `(bool, [string])`. Now all cases behave the same.
 * Fixed spelling error (Transimitted ==> transmitted)
 * Fixed a bug where StateValidError identified itself as TransitionError
 * Fixed PEP8/flake8 issues

You can enable warnings by running tests this way --
```
python -W default  manage.py test -v 2
```

A warning about warnings -- you'll get a flood, some relevant, some not, mostly from 3rd party packages.
