### PR TITLE
Make naive datetimes TZ-aware in t2f factories

### DIFF
--- a/EquiTrack/t2f/tests/factories.py
+++ b/EquiTrack/t2f/tests/factories.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
 
-from datetime import datetime, timedelta
+from datetime import timedelta
+
+from django.utils import timezone
+
 import factory
 from factory import fuzzy
-from pytz import timezone, UTC
 
-from django.conf import settings
 
 from EquiTrack.factories import UserFactory, OfficeFactory, SectionFactory, ResultFactory, LocationFactory,\
     InterventionFactory
@@ -15,9 +16,8 @@ from t2f.models import Travel, TravelActivity, IteneraryItem, Expense, Deduction
     ActionPoint, make_travel_reference_number, make_action_point_number, ModeOfTravel, \
     TravelType, Invoice, InvoiceItem
 
-TZ = timezone(settings.TIME_ZONE)
-_FUZZY_START_DATE = TZ.localize(datetime.now() - timedelta(days=5))
-_FUZZY_END_DATE = TZ.localize(datetime.now() + timedelta(days=5))
+_FUZZY_START_DATE = timezone.now() - timedelta(days=5)
+_FUZZY_END_DATE = timezone.now() + timedelta(days=5)
 
 
 class TravelActivityFactory(factory.django.DjangoModelFactory):
@@ -25,7 +25,7 @@ class TravelActivityFactory(factory.django.DjangoModelFactory):
     partner = factory.SelfAttribute('partnership.agreement.partner')
     partnership = factory.SubFactory(InterventionFactory)
     result = factory.SubFactory(ResultFactory)
-    date = factory.LazyAttribute(lambda o: datetime.now())
+    date = factory.LazyAttribute(lambda o: timezone.now())
 
     class Meta:
         model = TravelActivity
@@ -39,8 +39,8 @@ class TravelActivityFactory(factory.django.DjangoModelFactory):
 class IteneraryItemFactory(factory.DjangoModelFactory):
     origin = fuzzy.FuzzyText(length=32)
     destination = fuzzy.FuzzyText(length=32)
-    departure_date = fuzzy.FuzzyDateTime(start_dt=_FUZZY_START_DATE, end_dt=TZ.localize(datetime.now()))
-    arrival_date = fuzzy.FuzzyDateTime(start_dt=TZ.localize(datetime.now()), end_dt=_FUZZY_END_DATE)
+    departure_date = fuzzy.FuzzyDateTime(start_dt=_FUZZY_START_DATE, end_dt=timezone.now())
+    arrival_date = fuzzy.FuzzyDateTime(start_dt=timezone.now(), end_dt=_FUZZY_END_DATE)
     dsa_region = factory.SubFactory(DSARegionFactory)
     overnight_travel = False
     mode_of_travel = ModeOfTravel.BOAT
@@ -97,11 +97,11 @@ class ClearanceFactory(factory.DjangoModelFactory):
 class ActionPointFactory(factory.DjangoModelFactory):
     action_point_number = factory.Sequence(lambda n: make_action_point_number())
     description = fuzzy.FuzzyText(length=128)
-    due_date = fuzzy.FuzzyDateTime(start_dt=_FUZZY_START_DATE, end_dt=TZ.localize(datetime.now()))
+    due_date = fuzzy.FuzzyDateTime(start_dt=_FUZZY_START_DATE, end_dt=timezone.now())
     person_responsible = factory.SubFactory(UserFactory)
     assigned_by = factory.SubFactory(UserFactory)
     status = 'open'
-    created_at = datetime.now(tz=UTC)
+    created_at = timezone.now()
 
     class Meta:
         model = ActionPoint
@@ -112,8 +112,8 @@ class TravelFactory(factory.DjangoModelFactory):
     supervisor = factory.SubFactory(UserFactory)
     office = factory.SubFactory(OfficeFactory)
     section = factory.SubFactory(SectionFactory)
-    start_date = fuzzy.FuzzyDateTime(start_dt=_FUZZY_START_DATE, end_dt=TZ.localize(datetime.now()))
-    end_date = fuzzy.FuzzyDateTime(start_dt=TZ.localize(datetime.now()), end_dt=_FUZZY_END_DATE)
+    start_date = fuzzy.FuzzyDateTime(start_dt=_FUZZY_START_DATE, end_dt=timezone.now())
+    end_date = fuzzy.FuzzyDateTime(start_dt=timezone.now(), end_dt=_FUZZY_END_DATE)
     purpose = factory.Sequence(lambda n: 'Purpose #{}'.format(n))
     international_travel = False
     ta_required = True


### PR DESCRIPTION
Timestamps were being deliberately localized in the factories. When run with warnings enabled, this generated 102 warnings of this type --

```
RuntimeWarning: DateTimeField FundingCommitment.start received a naive datetime (2017-01-01 00:00:00) while time zone support is active.
```

Per @ewheeler , t2f was deliberately coded this way in anticipation of some change that never came to pass, so it's OK to simply add a UTC timestamp here.

