### PR TITLE
Change TZ-naive datetimes to plain dates in t2 migrations

### DIFF
--- a/EquiTrack/t2f/migrations/0008_auto_20170323_1111.py
+++ b/EquiTrack/t2f/migrations/0008_auto_20170323_1111.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import datetime
 
 from django.db import migrations
+from django.utils import timezone
 
 
 def set_clearances_for_old_trips(apps, schema_editor):
@@ -17,7 +18,7 @@ def set_clearances_for_old_trips(apps, schema_editor):
     Travel = apps.get_model("t2f", "Travel")
     Clearances = apps.get_model("t2f", "Clearances")
 
-    six_months_ago = datetime.date.today() - datetime.timedelta(days=180)
+    six_months_ago = timezone.now() - datetime.timedelta(days=180)
     for travel in Travel.objects.filter(created__lt=six_months_ago):
         clearances = Clearances(travel=travel)
         clearances.save()

--- a/EquiTrack/t2f/migrations/0008_auto_20170323_1111.py
+++ b/EquiTrack/t2f/migrations/0008_auto_20170323_1111.py
@@ -17,7 +17,7 @@ def set_clearances_for_old_trips(apps, schema_editor):
     Travel = apps.get_model("t2f", "Travel")
     Clearances = apps.get_model("t2f", "Clearances")
 
-    six_months_ago = datetime.datetime.today() - datetime.timedelta(days=180)
+    six_months_ago = datetime.date.today() - datetime.timedelta(days=180)
     for travel in Travel.objects.filter(created__lt=six_months_ago):
         clearances = Clearances(travel=travel)
         clearances.save()

--- a/EquiTrack/t2f/migrations/0010_fix_clearances.py
+++ b/EquiTrack/t2f/migrations/0010_fix_clearances.py
@@ -17,7 +17,7 @@ def set_clearances_for_old_trips(apps, schema_editor):
     Travel = apps.get_model("t2f", "Travel")
     Clearances = apps.get_model("t2f", "Clearances")
 
-    six_months_ago = datetime.datetime.today() - datetime.timedelta(days=180)
+    six_months_ago = datetime.date.today() - datetime.timedelta(days=180)
     for travel in Travel.objects.filter(created__gt=six_months_ago):
         if not hasattr(travel, 'clearances'):
             # creating Clearances

--- a/EquiTrack/t2f/migrations/0010_fix_clearances.py
+++ b/EquiTrack/t2f/migrations/0010_fix_clearances.py
@@ -4,6 +4,7 @@ from __future__ import unicode_literals
 import datetime
 
 from django.db import migrations
+from django.utils import timezone
 
 
 def set_clearances_for_old_trips(apps, schema_editor):
@@ -17,7 +18,7 @@ def set_clearances_for_old_trips(apps, schema_editor):
     Travel = apps.get_model("t2f", "Travel")
     Clearances = apps.get_model("t2f", "Clearances")
 
-    six_months_ago = datetime.date.today() - datetime.timedelta(days=180)
+    six_months_ago = timezone.now() - datetime.timedelta(days=180)
     for travel in Travel.objects.filter(created__gt=six_months_ago):
         if not hasattr(travel, 'clearances'):
             # creating Clearances


### PR DESCRIPTION
Two t2f migrations were filtering instances by comparing naive timestamps against a TZ-aware field. I changed them to use TZ-aware timestamps.

