### PR TITLE
Fix trips unicode references (Python 3 compatibility)

### DIFF
--- a/EquiTrack/trips/exports.py
+++ b/EquiTrack/trips/exports.py
@@ -32,10 +32,10 @@ class TripResource(BaseExportResource):
         return row
 
     def fill_trip_pcas(self, row, trip):
-        pcas = set(lp.intervention.__unicode__() for lp in trip.linkedpartner_set.all() if lp.intervention)
+        pcas = set(unicode(lp.intervention) for lp in trip.linkedpartner_set.all() if lp.intervention)
 
         pcas.union(
-            set(lgp.intervention.__unicode__() for lgp in trip.linkedgovernmentpartner_set.all() if lgp.intervention)
+            set(unicode(lgp.intervention) for lgp in trip.linkedgovernmentpartner_set.all() if lgp.intervention)
         )
         self.insert_column(
             row,
@@ -100,7 +100,7 @@ class ActionPointResource(BaseExportResource):
 
     def fill_row(self, action, row):
 
-        self.insert_column(row, 'Trip', action.trip.__unicode__())
+        self.insert_column(row, 'Trip', unicode(action.trip))
         self.insert_column(row, 'Traveller', action.trip.owner)
         self.insert_column(row, 'Section', action.trip.section)
         self.insert_column(row, 'Office', action.trip.office)

--- a/EquiTrack/trips/models.py
+++ b/EquiTrack/trips/models.py
@@ -404,7 +404,7 @@ class Trip(AdminURLMixin, models.Model):
                 instance.get_admin_url()),
             'purpose_of_travel': instance.purpose_of_travel,
             'environment': get_environment(),
-            'action_points': ('\n'.join([action.__unicode__() for action in instance.actionpoint_set.all()]))
+            'action_points': ('\n'.join([unicode(action) for action in instance.actionpoint_set.all()]))
         }
 
         if instance.status == Trip.SUBMITTED:

--- a/EquiTrack/trips/serializers.py
+++ b/EquiTrack/trips/serializers.py
@@ -128,7 +128,7 @@ class TripSerializer(serializers.ModelSerializer):
     files = FileAttachmentSerializer(many=True, read_only=True)
 
     def get_partnerships(self, trip):
-        return [pca.__unicode__() for pca in trip.pcas.all()]
+        return [unicode(pca) for pca in trip.pcas.all()]
 
     def transform_traveller(self, obj):
         return obj.owner.get_full_name()


### PR DESCRIPTION
Switch to `unicode(object)` rather than `object.__unicode__()`. The latter can't be automatically translated by the 2to3 tool. No functional change.