### PR TITLE
Fix partners attachment test

### DIFF
--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -820,6 +820,7 @@ class TestAgreementAPIFileAttachments(APITenantTestCase):
         self.assertIn(url.scheme, ('http', 'https'))
         self.assertEqual(url.netloc, 'testserver')
 
+        # The filename is probably 'hello_world.txt', but Django doesn't guarantee that so I don't test it.
         expected_path_components = ['',
                                     settings.MEDIA_URL.strip('/'),
                                     connection.schema_name,
@@ -830,9 +831,8 @@ class TestAgreementAPIFileAttachments(APITenantTestCase):
                                     # Note that slashes have to be stripped from the agreement number to match the
                                     # normalized path.
                                     self.agreement.agreement_number.strip('/'),
-                                    'hello_world.txt']
-
-        self.assertEqual(expected_path_components, url.path.split('/'))
+                                    ]
+        self.assertEqual(expected_path_components, url.path.split('/')[:-1])
 
         # Confirm that there are no amendments as of yet.
         self.assertIn('amendments', response_json)
@@ -861,6 +861,7 @@ class TestAgreementAPIFileAttachments(APITenantTestCase):
         self.assertIn(url.scheme, ('http', 'https'))
         self.assertEqual(url.netloc, 'testserver')
 
+        # The filename is probably 'goodbye_world.txt', but Django doesn't guarantee that so I don't test it.
         expected_path_components = ['',
                                     settings.MEDIA_URL.strip('/'),
                                     connection.schema_name,
@@ -871,9 +872,8 @@ class TestAgreementAPIFileAttachments(APITenantTestCase):
                                     self.agreement.base_number.strip('/'),
                                     'amendments',
                                     amendment.number.strip('/'),
-                                    'goodbye_world.txt']
-
-        self.assertEqual(expected_path_components, url.path.split('/'))
+                                    ]
+        self.assertEqual(expected_path_components, url.path.split('/')[:-1])
 
 
 class TestAgreementAPIView(APITenantTestCase):


### PR DESCRIPTION
This fixes a test that I recently added which sometimes breaks because it assumes that files uploaded to Django will retain their exact name which is not true. Django reserves the right to change the name of uploaded files to avoid name conflicts. At present it just adds a random 7-character string to the existing filename if there's a conflict; the code is here --
https://github.com/django/django/blob/1.9.13/django/core/files/storage.py#L84

Rather than write a test that depends on the exact behavior of Django's internals, this PR removes filename checking from the test.