### PR TITLE
Convert funds models to Python 3-compatible str() methods

### DIFF
--- a/EquiTrack/EquiTrack/factories.py
+++ b/EquiTrack/EquiTrack/factories.py
@@ -15,7 +15,14 @@ from trips import models as trip_models
 from reports import models as report_models
 from locations import models as location_models
 from partners import models as partner_models
-from funds.models import Grant, Donor, FundsReservationHeader, FundsCommitmentHeader
+from funds.models import (
+    Donor,
+    FundsCommitmentHeader,
+    FundsCommitmentItem,
+    FundsReservationHeader,
+    FundsReservationItem,
+    Grant,
+    )
 from notification import models as notification_models
 from workplan import models as workplan_models
 from workplan.models import WorkplanProject, CoverPage, CoverPageBudget
@@ -378,6 +385,14 @@ class GrantFactory(factory.DjangoModelFactory):
         model = Grant
 
 
+class FundsCommitmentItemFactory(factory.DjangoModelFactory):
+    fund_commitment = factory.SubFactory('EquiTrack.factories.FundsCommitmentHeaderFactory')
+    line_item = fuzzy.FuzzyText(length=5)
+
+    class Meta:
+        model = FundsCommitmentItem
+
+
 class FundsReservationHeaderFactory(factory.DjangoModelFactory):
     intervention = factory.SubFactory(InterventionFactory)
     vendor_code = fuzzy.FuzzyText(length=20)
@@ -401,6 +416,14 @@ class FundsReservationHeaderFactory(factory.DjangoModelFactory):
 
     class Meta:
         model = FundsReservationHeader
+
+
+class FundsReservationItemFactory(factory.DjangoModelFactory):
+    class Meta:
+        model = FundsReservationItem
+
+    fund_reservation = factory.SubFactory(FundsReservationHeaderFactory)
+    line_item = fuzzy.FuzzyText(length=5)
 
 
 class FundsCommitmentHeaderFactory(factory.DjangoModelFactory):

--- a/EquiTrack/funds/models.py
+++ b/EquiTrack/funds/models.py
@@ -1,7 +1,9 @@
 from django.db import models
 from django.utils import timezone
+from django.utils.encoding import python_2_unicode_compatible
 
 
+@python_2_unicode_compatible
 class Donor(models.Model):
     """
     Represents Donor for a Grant.
@@ -12,7 +14,7 @@ class Donor(models.Model):
     class Meta:
         ordering = ['name']
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -21,6 +23,7 @@ class GrantManager(models.Manager):
         return super(GrantManager, self).get_queryset().select_related('donor')
 
 
+@python_2_unicode_compatible
 class Grant(models.Model):
     """
     Represents the name of a Grant with expiration date, and Donor name.
@@ -38,13 +41,14 @@ class Grant(models.Model):
     class Meta:
         ordering = ['donor']
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{}: {}".format(
             self.donor.name,
             self.name
         )
 
 
+@python_2_unicode_compatible
 class FundsReservationHeader(models.Model):
     intervention = models.ForeignKey('partners.Intervention', related_name='frs', blank=True, null=True)
     vendor_code = models.CharField(max_length=20)
@@ -65,9 +69,9 @@ class FundsReservationHeader(models.Model):
     start_date = models.DateField(null=True, blank=True)
     end_date = models.DateField(null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'{}'.format(
-            self.fr_number,
+            self.fr_number
         )
 
     class Meta:
@@ -80,6 +84,7 @@ class FundsReservationHeader(models.Model):
         return self.end_date < today
 
 
+@python_2_unicode_compatible
 class FundsReservationItem(models.Model):
     fund_reservation = models.ForeignKey(FundsReservationHeader, related_name="fr_items")
     fr_ref_number = models.CharField(max_length=30, null=True, blank=True)
@@ -94,9 +99,9 @@ class FundsReservationItem(models.Model):
     due_date = models.DateField(null=True, blank=True)
     line_item_text = models.CharField(max_length=255, null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'{}'.format(
-            self.fr_ref_number,
+            self.fr_ref_number
         )
 
     class Meta:
@@ -108,6 +113,7 @@ class FundsReservationItem(models.Model):
         return super(FundsReservationItem, self).save(**kwargs)
 
 
+@python_2_unicode_compatible
 class FundsCommitmentHeader(models.Model):
     vendor_code = models.CharField(max_length=20)
     fc_number = models.CharField(max_length=20, unique=True)
@@ -118,12 +124,13 @@ class FundsCommitmentHeader(models.Model):
     exchange_rate = models.CharField(max_length=20, null=True, blank=True)
     responsible_person = models.CharField(max_length=100, blank=True, null=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'{}'.format(
-            self.fc_number,
+            self.fc_number
         )
 
 
+@python_2_unicode_compatible
 class FundsCommitmentItem(models.Model):
     fund_commitment = models.ForeignKey(FundsCommitmentHeader, related_name='fc_items')
     fc_ref_number = models.CharField(max_length=30, null=True, blank=True)
@@ -139,9 +146,9 @@ class FundsCommitmentItem(models.Model):
     amount_changed = models.DecimalField(default=0, max_digits=12, decimal_places=2)
     line_item_text = models.CharField(max_length=255, null=True, blank=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return u'{}'.format(
-            self.fc_ref_number,
+            self.fc_ref_number
         )
 
     class Meta:

--- a/EquiTrack/funds/tests/test_models.py
+++ b/EquiTrack/funds/tests/test_models.py
@@ -3,9 +3,64 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from EquiTrack.factories import FundsReservationHeaderFactory, FundsCommitmentHeaderFactory
+import sys
+from unittest import skipIf
+
+from EquiTrack.factories import (
+    DonorFactory,
+    FundsCommitmentHeaderFactory,
+    FundsCommitmentItemFactory,
+    FundsReservationHeaderFactory,
+    FundsReservationItemFactory,
+    GrantFactory,
+    )
 from EquiTrack.tests.mixins import FastTenantTestCase
 from funds.models import FundsReservationItem, FundsCommitmentItem
+
+
+@skipIf(sys.version_info.major == 3, "This test can be deleted under Python 3")
+class TestStrUnicode(FastTenantTestCase):
+    '''Ensure calling str() on model instances returns UTF8-encoded text and unicode() returns unicode.'''
+    def test_donor(self):
+        donor = DonorFactory.build(name=u'R\xe4dda Barnen')
+        self.assertEqual(str(donor), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(donor), u'R\xe4dda Barnen')
+
+    def test_grant(self):
+        donor = DonorFactory.build(name=b'xyz')
+        grant = GrantFactory.build(donor=donor, name=u'R\xe4dda Barnen')
+        self.assertEqual(str(grant), b'xyz: R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(grant), u'xyz: R\xe4dda Barnen')
+
+        donor = DonorFactory.build(name=u'xyz')
+        grant = GrantFactory.build(donor=donor, name=u'R\xe4dda Barnen')
+        self.assertEqual(str(grant), b'xyz: R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(grant), u'xyz: R\xe4dda Barnen')
+
+        donor = DonorFactory.build(name=u'R\xe4dda Barnen')
+        grant = GrantFactory.build(donor=donor, name=b'xyz')
+        self.assertEqual(str(grant), b'R\xc3\xa4dda Barnen: xyz')
+        self.assertEqual(unicode(grant), u'R\xe4dda Barnen: xyz')
+
+    def test_funds_reservation_header(self):
+        funds_reservation_header = FundsReservationHeaderFactory.build(fr_number=u'R\xe4dda Barnen')
+        self.assertEqual(str(funds_reservation_header), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(funds_reservation_header), u'R\xe4dda Barnen')
+
+    def test_funds_reservation_item(self):
+        funds_reservation_item = FundsReservationItemFactory.build(fr_ref_number=u'R\xe4dda Barnen')
+        self.assertEqual(str(funds_reservation_item), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(funds_reservation_item), u'R\xe4dda Barnen')
+
+    def test_funds_commitment_header(self):
+        funds_commitment_header = FundsCommitmentHeaderFactory.build(fc_number=u'R\xe4dda Barnen')
+        self.assertEqual(str(funds_commitment_header), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(funds_commitment_header), u'R\xe4dda Barnen')
+
+    def test_funds_commitment_item(self):
+        funds_commitment_item = FundsCommitmentItemFactory.build(fc_ref_number=u'R\xe4dda Barnen')
+        self.assertEqual(str(funds_commitment_item), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(funds_commitment_item), u'R\xe4dda Barnen')
 
 
 class TestFundsReservationItem(FastTenantTestCase):


### PR DESCRIPTION
Convert all models in `funds` to Python 3-compatible `__str()__` methods using Django's `@python_2_unicode_compatible decorator` while retaining compatibility with Python 2.

https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.encoding.python_2_unicode_compatible

Add non-ASCII tests for `str()` and `unicode()` methods for each model.

Add factories as necessary for tests.
