### PR TITLE
Convert locations models to Python 3-compatible str() methods

### DIFF
--- a/EquiTrack/EquiTrack/factories.py
+++ b/EquiTrack/EquiTrack/factories.py
@@ -128,6 +128,17 @@ class LocationFactory(factory.django.DjangoModelFactory):
     p_code = factory.Sequence(lambda n: 'PCODE{}'.format(n))
 
 
+class CartoDBTableFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = location_models.CartoDBTable
+
+    domain = factory.Sequence(lambda n: 'Domain {}'.format(n))
+    api_key = factory.Sequence(lambda n: 'API Key {}'.format(n))
+    table_name = factory.Sequence(lambda n: 'table_name_{}'.format(n))
+    location_type = factory.SubFactory(GatewayTypeFactory)
+    domain = factory.Sequence(lambda n: 'Domain {}'.format(n))
+
+
 class PartnerStaffFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = partner_models.PartnerStaffMember

--- a/EquiTrack/locations/models.py
+++ b/EquiTrack/locations/models.py
@@ -6,6 +6,7 @@ from django.core.cache import cache
 from django.db import connection
 from django.db.models.signals import post_delete, post_save
 from django.dispatch.dispatcher import receiver
+from django.utils.encoding import python_2_unicode_compatible
 
 from mptt.models import MPTTModel, TreeForeignKey
 from paintstore.fields import ColorPickerField
@@ -21,6 +22,7 @@ def get_random_color():
     )
 
 
+@python_2_unicode_compatible
 class GatewayType(models.Model):
     """
     Represents an Admin Type in location-related models.
@@ -32,7 +34,7 @@ class GatewayType(models.Model):
         ordering = ['name']
         verbose_name = 'Location Type'
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -42,6 +44,7 @@ class LocationManager(models.Manager):
         return super(LocationManager, self).get_queryset().select_related('gateway')
 
 
+@python_2_unicode_compatible
 class Location(MPTTModel):
     """
     Represents Location, either a point or geospatial object,
@@ -62,7 +65,7 @@ class Location(MPTTModel):
 
     objects = LocationManager()
 
-    def __unicode__(self):
+    def __str__(self):
         # TODO: Make generic
         return u'{} ({} {}: {})'.format(
             self.name,
@@ -97,6 +100,7 @@ def invalidate_locations_etag(sender, instance, **kwargs):
     cache.delete("{}-locations-etag".format(schema_name))
 
 
+@python_2_unicode_compatible
 class CartoDBTable(MPTTModel):
     """
     Represents a table in CartoDB, it is used to import locations
@@ -115,5 +119,5 @@ class CartoDBTable(MPTTModel):
     parent = TreeForeignKey('self', null=True, blank=True, related_name='children', db_index=True)
     color = ColorPickerField(null=True, blank=True, default=get_random_color)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.table_name

--- a/EquiTrack/locations/tests/test_models.py
+++ b/EquiTrack/locations/tests/test_models.py
@@ -1,0 +1,48 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import sys
+from unittest import skipIf, TestCase
+
+from EquiTrack.factories import (
+    CartoDBTableFactory,
+    GatewayTypeFactory,
+    LocationFactory,
+    )
+
+
+@skipIf(sys.version_info.major == 3, "This test can be deleted under Python 3")
+class TestStrUnicode(TestCase):
+    '''Ensure calling str() on model instances returns UTF8-encoded text and unicode() returns unicode.'''
+    def test_gateway_type(self):
+        gateway_type = GatewayTypeFactory.build(name=b'xyz')
+        self.assertEqual(str(gateway_type), b'xyz')
+        self.assertEqual(unicode(gateway_type), u'xyz')
+
+        gateway_type = GatewayTypeFactory.build(name=u'R\xe4dda Barnen')
+        self.assertEqual(str(gateway_type), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(gateway_type), u'R\xe4dda Barnen')
+
+    def test_location(self):
+        # Test with unicode gateway name
+        gateway_type = GatewayTypeFactory.build(name=u'xyz')
+        location = LocationFactory.build(gateway=gateway_type, name=u'R\xe4dda Barnen', p_code='abc')
+        self.assertEqual(str(location), b'R\xc3\xa4dda Barnen (xyz PCode: abc)')
+        self.assertEqual(unicode(location), u'R\xe4dda Barnen (xyz PCode: abc)')
+
+        # Test with str gateway name
+        gateway_type = GatewayTypeFactory.build(name=b'xyz')
+        location = LocationFactory.build(gateway=gateway_type, name=u'R\xe4dda Barnen', p_code='abc')
+        self.assertEqual(str(location), b'R\xc3\xa4dda Barnen (xyz PCode: abc)')
+        self.assertEqual(unicode(location), u'R\xe4dda Barnen (xyz PCode: abc)')
+
+    def test_carto_db_table(self):
+        carto_db_table = CartoDBTableFactory.build(table_name=u'R\xe4dda Barnen')
+        self.assertEqual(str(carto_db_table), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(carto_db_table), u'R\xe4dda Barnen')
+
+        carto_db_table = CartoDBTableFactory.build(table_name=b'xyz')
+        self.assertEqual(str(carto_db_table), b'xyz')
+        self.assertEqual(unicode(carto_db_table), u'xyz')


### PR DESCRIPTION
Convert all models in `locations` to Python 3-compatible `__str()__` methods using Django's `@python_2_unicode_compatible decorator` while retaining compatibility with Python 2.

https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.encoding.python_2_unicode_compatible

Add non-ASCII tests for `str()` and `unicode()` methods for each model.

Add factories as necessary for tests.
