### PR TITLE
Convert Notification model to Python 3-compatible __str()__ method

### DIFF
--- a/EquiTrack/notification/models.py
+++ b/EquiTrack/notification/models.py
@@ -11,6 +11,7 @@ from django.db import models
 from django.contrib.contenttypes.fields import GenericForeignKey
 from django.contrib.contenttypes.models import ContentType
 from django.template.base import Template, VariableNode
+from django.utils.encoding import python_2_unicode_compatible
 
 from model_utils import Choices
 from post_office import mail
@@ -20,6 +21,7 @@ from post_office.models import EmailTemplate
 logger = logging.getLogger(__name__)
 
 
+@python_2_unicode_compatible
 class Notification(models.Model):
     """
     Represents a notification instance from sender to recipients
@@ -58,7 +60,7 @@ class Notification(models.Model):
     template_name = models.CharField(max_length=255)
     template_data = JSONField()
 
-    def __unicode__(self):
+    def __str__(self):
         return u"{} Notification from {}: {}".format(self.type, self.sender, self.template_data)
 
     def send_notification(self):

--- a/EquiTrack/notification/tests/test_email.py
+++ b/EquiTrack/notification/tests/test_email.py
@@ -5,7 +5,7 @@ from mock import patch
 from post_office.models import EmailTemplate, Email
 
 from EquiTrack.tests.mixins import FastTenantTestCase
-from EquiTrack.factories import NotificationFactory, UserFactory, PartnerFactory, AgreementFactory
+from EquiTrack.factories import NotificationFactory, UserFactory
 from notification.models import Notification
 
 
@@ -51,17 +51,6 @@ class TestSendNotification(FastTenantTestCase):
     this only tests that if a non-email type is created, we don't do anything
     with it.
     """
-
-    def test_unicode_method_safe(self):
-        "Smoke test for __unicode__ method"
-        # Create a notification that will contain non-ASCII. Radda Barnen == Save the Children in Sweden.
-        agreement = AgreementFactory(partner=PartnerFactory(name=u'R\xe4dda Barnen'))
-        notification = NotificationFactory(sender=agreement)
-        # Conversion to Unicode shouldn't raise an error.
-        notification = unicode(notification)
-        self.assertIn('Notification from', notification)
-        self.assertIn(u'R\xe4dda', notification)
-
     def test_send_not_email(self):
         """
         This just tests that if we currently send a non Email notification,

--- a/EquiTrack/notification/tests/test_models.py
+++ b/EquiTrack/notification/tests/test_models.py
@@ -1,0 +1,35 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import sys
+from unittest import skipIf
+
+from EquiTrack.factories import (
+    AgreementFactory,
+    NotificationFactory,
+    PartnerFactory
+    )
+from EquiTrack.tests.mixins import FastTenantTestCase
+
+
+@skipIf(sys.version_info.major == 3, "This test can be deleted under Python 3")
+class TestStrUnicode(FastTenantTestCase):
+    '''Ensure calling str() on model instances returns UTF8-encoded text and unicode() returns unicode.'''
+    def test_notification(self):
+        agreement = AgreementFactory(partner=PartnerFactory(name=b'xyz'))
+        notification = NotificationFactory(sender=agreement)
+        self.assertIn(b'Email Notification from', str(notification))
+        self.assertIn(b'for xyz', str(notification))
+
+        self.assertIn(u'Email Notification from', unicode(notification))
+        self.assertIn(u'for xyz', unicode(notification))
+
+        agreement = AgreementFactory(partner=PartnerFactory(name=u'R\xe4dda Barnen'))
+        notification = NotificationFactory(sender=agreement)
+        self.assertIn(b'Email Notification from', str(notification))
+        self.assertIn(b'for R\xc3\xa4dda Barnen', str(notification))
+
+        self.assertIn(u'Email Notification from', unicode(notification))
+        self.assertIn(u'for R\xe4dda Barnen', unicode(notification))


### PR DESCRIPTION
Convert `Notification` model to Python 3-compatible `__str()__` methods using Django's `@python_2_unicode_compatible decorator` while retaining compatibility with Python 2.

https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.encoding.python_2_unicode_compatible

Add non-ASCII tests for `str()` and `unicode()` methods. 

Remove redundant test from `test_email.py`.