### PR TITLE
Fix three spelling typos in partners (PRP-refactor)

### DIFF
--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -701,7 +701,7 @@ class Assessment(models.Model):
     Relates to :model:`auth.User`
     """
 
-    ASSESMENT_TYPES = (
+    ASSESSMENT_TYPES = (
         ('Micro Assessment', 'Micro Assessment'),
         ('Simplified Checklist', 'Simplified Checklist'),
         ('Scheduled Audit report', 'Scheduled Audit report'),
@@ -715,7 +715,7 @@ class Assessment(models.Model):
     )
     type = models.CharField(
         max_length=50,
-        choices=ASSESMENT_TYPES,
+        choices=ASSESSMENT_TYPES,
     )
     names_of_other_agencies = models.CharField(
         max_length=255,

--- a/EquiTrack/partners/permissions.py
+++ b/EquiTrack/partners/permissions.py
@@ -155,7 +155,7 @@ class PartnerPermission(permissions.BasePermission):
             return self._has_access_permissions(request.user, obj)
 
 
-class PartneshipManagerPermission(permissions.BasePermission):
+class PartnershipManagerPermission(permissions.BasePermission):
     message = 'Accessing this item is not allowed.'
 
     def _has_access_permissions(self, user, object):
@@ -184,7 +184,7 @@ class PartneshipManagerPermission(permissions.BasePermission):
                 request.user.groups.filter(name='Partnership Manager').exists()
 
 
-class PartneshipManagerRepPermission(permissions.BasePermission):
+class PartnershipManagerRepPermission(permissions.BasePermission):
     message = 'Accessing this item is not allowed.'
 
     def _has_access_permissions(self, user, object):

--- a/EquiTrack/partners/views/agreements_v2.py
+++ b/EquiTrack/partners/views/agreements_v2.py
@@ -29,7 +29,7 @@ from partners.serializers.agreements_v2 import (
 )
 
 from partners.filters import PartnerScopeFilter
-from partners.permissions import PartneshipManagerRepPermission, PartneshipManagerPermission
+from partners.permissions import PartnershipManagerRepPermission, PartnershipManagerPermission
 
 from partners.exports_v2 import AgreementCvsRenderer
 from EquiTrack.validation_mixins import ValidatorViewMixin
@@ -43,7 +43,7 @@ class AgreementListAPIView(ValidatorViewMixin, ListCreateAPIView):
     """
     serializer_class = AgreementListSerializer
     filter_backends = (PartnerScopeFilter,)
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     renderer_classes = (r.JSONRenderer, AgreementCvsRenderer)
 
     SERIALIZER_MAP = {
@@ -136,7 +136,7 @@ class AgreementDetailAPIView(ValidatorViewMixin, RetrieveUpdateDestroyAPIView):
     """
     queryset = Agreement.objects.all()
     serializer_class = AgreementDetailSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
 
     SERIALIZER_MAP = {
         'amendments': AgreementAmendmentCreateUpdateSerializer
@@ -173,7 +173,7 @@ class AgreementDetailAPIView(ValidatorViewMixin, RetrieveUpdateDestroyAPIView):
 
 
 class AgreementAmendmentDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:

--- a/EquiTrack/partners/views/interventions_v2.py
+++ b/EquiTrack/partners/views/interventions_v2.py
@@ -46,7 +46,7 @@ from partners.exports_v2 import InterventionCvsRenderer
 from partners.filters import PartnerScopeFilter, InterventionResultLinkFilter, InterventionFilter, \
     AppliedIndicatorsFilter
 from partners.validation.interventions import InterventionValid
-from partners.permissions import PartneshipManagerRepPermission, PartneshipManagerPermission
+from partners.permissions import PartnershipManagerRepPermission, PartnershipManagerPermission
 from reports.models import LowerResult, AppliedIndicator
 from reports.serializers.v2 import LowerResultSimpleCUSerializer, AppliedIndicatorSerializer
 
@@ -57,7 +57,7 @@ class InterventionListAPIView(ValidatorViewMixin, ListCreateAPIView):
     Returns a list of Interventions.
     """
     serializer_class = InterventionListSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (PartnerScopeFilter,)
     renderer_classes = (r.JSONRenderer, InterventionCvsRenderer)
 
@@ -213,7 +213,7 @@ class InterventionDetailAPIView(ValidatorViewMixin, RetrieveUpdateDestroyAPIView
     """
     queryset = Intervention.objects.detail_qs().all()
     serializer_class = InterventionDetailSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
 
     SERIALIZER_MAP = {
         'planned_budget': InterventionBudgetCUSerializer,
@@ -258,7 +258,7 @@ class InterventionDetailAPIView(ValidatorViewMixin, RetrieveUpdateDestroyAPIView
 
 
 class InterventionPlannedVisitsDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -277,7 +277,7 @@ class InterventionPlannedVisitsDeleteView(DestroyAPIView):
 
 
 class InterventionAttachmentDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -296,7 +296,7 @@ class InterventionAttachmentDeleteView(DestroyAPIView):
 
 
 class InterventionResultLinkDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -315,7 +315,7 @@ class InterventionResultLinkDeleteView(DestroyAPIView):
 
 
 class InterventionAmendmentDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -333,7 +333,7 @@ class InterventionAmendmentDeleteView(DestroyAPIView):
 
 
 class InterventionSectorLocationLinkDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -384,7 +384,7 @@ class InterventionListMapView(ListCreateAPIView):
 class InterventionLowerResultListCreateView(ListCreateAPIView):
 
     serializer_class = LowerResultSimpleCUSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (InterventionResultLinkFilter,)
     renderer_classes = (r.JSONRenderer,)
     queryset = LowerResult.objects.all()
@@ -403,7 +403,7 @@ class InterventionLowerResultListCreateView(ListCreateAPIView):
 class InterventionLowerResultUpdateView(RetrieveUpdateDestroyAPIView):
 
     serializer_class = LowerResultSimpleCUSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (InterventionResultLinkFilter,)
     renderer_classes = (r.JSONRenderer,)
     queryset = LowerResult.objects.all()
@@ -419,7 +419,7 @@ class InterventionLowerResultUpdateView(RetrieveUpdateDestroyAPIView):
 class InterventionResultLinkListCreateView(ListCreateAPIView):
 
     serializer_class = InterventionResultLinkSimpleCUSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (InterventionFilter,)
     renderer_classes = (r.JSONRenderer,)
     queryset = InterventionResultLink.objects.all()
@@ -438,7 +438,7 @@ class InterventionResultLinkListCreateView(ListCreateAPIView):
 class InterventionResultLinkUpdateView(RetrieveUpdateDestroyAPIView):
 
     serializer_class = InterventionResultLinkSimpleCUSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (InterventionFilter,)
     renderer_classes = (r.JSONRenderer,)
     queryset = InterventionResultLink.objects.all()
@@ -454,7 +454,7 @@ class InterventionResultLinkUpdateView(RetrieveUpdateDestroyAPIView):
 
 class InterventionIndicatorsListView(ListCreateAPIView):
     serializer_class = AppliedIndicatorSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (AppliedIndicatorsFilter,)
     renderer_classes = (r.JSONRenderer,)
     queryset = AppliedIndicator.objects.all()
@@ -475,7 +475,7 @@ class InterventionIndicatorsListView(ListCreateAPIView):
 class InterventionIndicatorsUpdateView(RetrieveUpdateDestroyAPIView):
 
     serializer_class = AppliedIndicatorSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (AppliedIndicatorsFilter,)
     renderer_classes = (r.JSONRenderer,)
     queryset = AppliedIndicator.objects.all()

--- a/EquiTrack/partners/views/partner_organization_v2.py
+++ b/EquiTrack/partners/views/partner_organization_v2.py
@@ -39,7 +39,7 @@ from partners.serializers.partner_organization_v2 import (
     MinimalPartnerOrganizationListSerializer,
 )
 from t2f.models import TravelActivity
-from partners.permissions import PartneshipManagerRepPermission, PartneshipManagerPermission
+from partners.permissions import PartnershipManagerRepPermission, PartnershipManagerPermission
 from partners.filters import PartnerScopeFilter
 from partners.exports_v2 import PartnerOrganizationCsvRenderer, PartnerOrganizationHactCsvRenderer
 
@@ -235,7 +235,7 @@ class PartnerAuthorizedOfficersListAPIVIew(ListAPIView):
 
 
 class PartnerOrganizationAssessmentDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:
@@ -255,7 +255,7 @@ class PartnerOrganizationAddView(CreateAPIView):
         Returns a list of Partners.
         """
     serializer_class = PartnerOrganizationCreateUpdateSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
 
     # TODO: let's aim to standardize where mapping goes
     MAPPING = {
@@ -340,7 +340,7 @@ class PartnerOrganizationAddView(CreateAPIView):
 
 
 class PartnerOrganizationDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:

--- a/EquiTrack/partners/views/prp_v1.py
+++ b/EquiTrack/partners/views/prp_v1.py
@@ -6,7 +6,7 @@ from partners.models import (
     Intervention,
 )
 from partners.serializers.prp_v1 import PRPInterventionListSerializer
-from partners.permissions import PartneshipManagerPermission
+from partners.permissions import PartnershipManagerPermission
 
 
 class PRPInterventionListAPIView(ListAPIView):
@@ -15,7 +15,7 @@ class PRPInterventionListAPIView(ListAPIView):
     Returns a list of Interventions.
     """
     serializer_class = PRPInterventionListSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (PartnerScopeFilter,)
 
     def get_queryset(self, format=None):

--- a/EquiTrack/partners/views/v2.py
+++ b/EquiTrack/partners/views/v2.py
@@ -44,7 +44,7 @@ from partners.serializers.partner_organization_v2 import (
     PartnerStaffMemberPropertiesSerializer,
     PartnerStaffMemberCreateUpdateSerializer,
 )
-from partners.permissions import PartneshipManagerPermission, PartnerPermission
+from partners.permissions import PartnershipManagerPermission, PartnerPermission
 from partners.serializers.v1 import InterventionSerializer
 from partners.filters import PartnerScopeFilter
 
@@ -69,7 +69,7 @@ class PartnerInterventionListAPIView(ListAPIView):
 class AgreementInterventionsListAPIView(ListAPIView):
     serializer_class = InterventionSerializer
     filter_backends = (PartnerScopeFilter,)
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
 
     def list(self, request, partner_pk=None, pk=None, format=None):
         """
@@ -89,7 +89,7 @@ class AgreementInterventionsListAPIView(ListAPIView):
 class PartnerStaffMemberDetailAPIView(RetrieveUpdateDestroyAPIView):
     queryset = PartnerStaffMember.objects.all()
     serializer_class = PartnerStaffMemberDetailSerializer
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
     filter_backends = (PartnerScopeFilter,)
 
     def get_serializer_class(self, format=None):
@@ -104,7 +104,7 @@ class PartnerStaffMemberPropertiesAPIView(RetrieveAPIView):
     """
     serializer_class = PartnerStaffMemberPropertiesSerializer
     queryset = PartnerStaffMember.objects.all()
-    permission_classes = (PartneshipManagerPermission,)
+    permission_classes = (PartnershipManagerPermission,)
 
     def get_object(self):
         queryset = self.get_queryset()
@@ -162,7 +162,7 @@ class PmpStaticDropdownsListApiView(APIView):
                     flat=True).order_by('cso_type').distinct('cso_type')))
         partner_types = choices_to_json_ready(PartnerType.CHOICES)
         agency_choices = choices_to_json_ready(PartnerOrganization.AGENCY_CHOICES)
-        assessment_types = choices_to_json_ready(Assessment.ASSESMENT_TYPES)
+        assessment_types = choices_to_json_ready(Assessment.ASSESSMENT_TYPES)
         agreement_types = choices_to_json_ready(
             [typ for typ in Agreement.AGREEMENT_TYPES if typ[0] not in ['IC', 'AWP']])
         agreement_status = choices_to_json_ready(Agreement.STATUS_CHOICES)

--- a/EquiTrack/reports/views/v2.py
+++ b/EquiTrack/reports/views/v2.py
@@ -12,7 +12,7 @@ from reports.models import Result, CountryProgramme, Indicator, LowerResult, Dis
 from reports.serializers.v2 import OutputListSerializer,  MinimalOutputListSerializer, DisaggregationSerializer
 from reports.serializers.v1 import IndicatorSerializer
 from partners.models import Intervention
-from partners.permissions import PartneshipManagerRepPermission
+from partners.permissions import PartnershipManagerRepPermission
 
 
 class OutputListAPIView(ListAPIView):
@@ -103,7 +103,7 @@ class ResultIndicatorListAPIView(ListAPIView):
 
 
 class LowerResultsDeleteView(DestroyAPIView):
-    permission_classes = (PartneshipManagerRepPermission,)
+    permission_classes = (PartnershipManagerRepPermission,)
 
     def delete(self, request, *args, **kwargs):
         try:


### PR DESCRIPTION
In `partners/permissions.py`, changed this --
`PartneshipManagerPermission`
to this --
`PartnershipManagerPermission`   (<== added 'r')

And this --
`PartneshipManagerRepPermission`
to this --
`PartnershipManagerRepPermission`    (<== added 'r')

And in `partners/models.py`, changed this --
`ASSESMENT_TYPES`
to this --
`ASSESSMENT_TYPES`    (<== added 'S')

Naturally this affected a lot of other files...

Sorry, I know this is annoying but I figure it's best to correct these before they spread even further.