### PR TITLE
Convert partners models to Python 3-compatible str() methods

### DIFF
--- a/EquiTrack/EquiTrack/factories.py
+++ b/EquiTrack/EquiTrack/factories.py
@@ -15,6 +15,7 @@ from trips import models as trip_models
 from reports import models as report_models
 from locations import models as location_models
 from partners import models as partner_models
+from supplies import models as supplies_models
 from funds.models import (
     Donor,
     FundsCommitmentHeader,
@@ -475,3 +476,162 @@ class AgreementAmendmentFactory(factory.django.DjangoModelFactory):
     number = factory.Sequence(lambda n: '{:05}'.format(n))
     agreement = factory.SubFactory(AgreementFactory)
     types = [partner_models.AgreementAmendment.CLAUSE]
+
+
+class WorkspaceFileTypeFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.WorkspaceFileType
+
+    name = factory.Sequence(lambda n: 'workspace file type {}'.format(n))
+
+
+class AssessmentFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.Assessment
+
+    # type must be in partner_models.Assessment.ASSESSMENT_TYPES
+    type = 'Micro Assessment'
+    partner = factory.SubFactory(PartnerFactory)
+
+
+class InterventionAmendmentFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.InterventionAmendment
+
+    intervention = factory.SubFactory(InterventionFactory)
+
+
+class InterventionResultLinkFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.InterventionResultLink
+
+    intervention = factory.SubFactory(InterventionFactory)
+    cp_output = factory.SubFactory(ResultFactory)
+
+
+class FileTypeFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.FileType
+
+    name = partner_models.FileType.PROGRESS_REPORT
+
+
+class InterventionAttachmentFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.InterventionAttachment
+
+    intervention = factory.SubFactory(InterventionFactory)
+    type = factory.SubFactory(FileTypeFactory)
+
+
+class GovernmentInterventionResultFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.GovernmentInterventionResult
+
+    intervention = factory.SubFactory(GovernmentInterventionFactory)
+    result = factory.SubFactory(ResultFactory)
+    year = '2017'
+
+
+class SupplyItemFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = supplies_models.SupplyItem
+
+    name = factory.Sequence(lambda n: 'Supply item {}'.format(n))
+
+
+class DistributionPlanFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.DistributionPlan
+
+    intervention = factory.SubFactory(InterventionFactory)
+    item = factory.SubFactory(SupplyItemFactory)
+    quantity = 42
+
+
+class PCAFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.PCA
+
+    partner = factory.SubFactory(PartnerFactory)
+    title = factory.Sequence(lambda n: 'PCA {}'.format(n))
+    initiation_date = date.today()
+
+
+class RAMIndicatorFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.RAMIndicator
+
+    intervention = factory.SubFactory(PCAFactory)
+    result = factory.SubFactory(ResultFactory)
+
+
+class PCAFileFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.PCAFile
+
+    pca = factory.SubFactory(PCAFactory)
+    type = factory.SubFactory(FileTypeFactory)
+
+
+class PCAGrantFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.PCAGrant
+
+    partnership = factory.SubFactory(PCAFactory)
+    grant = factory.SubFactory(GrantFactory)
+
+
+class GwPCALocationFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.GwPCALocation
+
+    pca = factory.SubFactory(PCAFactory)
+
+
+class SectorFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = report_models.Sector
+
+    name = factory.Sequence(lambda n: 'Sector {}'.format(n))
+
+
+class PCASectorFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.PCASector
+
+    pca = factory.SubFactory(PCAFactory)
+    sector = factory.SubFactory(SectorFactory)
+
+
+class PartnershipBudgetFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.PartnershipBudget
+
+    partnership = factory.SubFactory(PCAFactory)
+
+
+class AuthorizedOfficerFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = partner_models.AuthorizedOfficer
+
+    agreement = factory.SubFactory(AgreementFactory)
+    officer = factory.SubFactory(PartnerStaffFactory)

--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -147,6 +147,7 @@ def get_agreement_amd_file_path(instance, filename):
 # TODO: move this to a workspace app for common configuration options
 
 
+@python_2_unicode_compatible
 class WorkspaceFileType(models.Model):
     """
     Represents a file type
@@ -154,7 +155,7 @@ class WorkspaceFileType(models.Model):
 
     name = models.CharField(max_length=64, unique=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -202,6 +203,7 @@ def hact_default():
     }
 
 
+@python_2_unicode_compatible
 class PartnerOrganization(AdminURLMixin, models.Model):
     """
     Represents a partner organization
@@ -379,7 +381,7 @@ class PartnerOrganization(AdminURLMixin, models.Model):
         ordering = ['name']
         unique_together = ('name', 'vendor_number')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def latest_assessment(self, type):
@@ -626,6 +628,7 @@ class PartnerStaffMemberManager(models.Manager):
         return super(PartnerStaffMemberManager, self).get_queryset().select_related('partner')
 
 
+@python_2_unicode_compatible
 class PartnerStaffMember(models.Model):
     """
     Represents a staff member at the partner organization.
@@ -656,7 +659,7 @@ class PartnerStaffMember(models.Model):
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
 
-    def __unicode__(self):
+    def __str__(self):
         return'{} {} ({})'.format(
             self.first_name,
             self.last_name,
@@ -685,6 +688,7 @@ class PartnerStaffMember(models.Model):
         return super(PartnerStaffMember, self).save(**kwargs)
 
 
+@python_2_unicode_compatible
 class Assessment(models.Model):
     """
     Represents an assessment for a partner organization.
@@ -761,7 +765,7 @@ class Assessment(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return'{type}: {partner} {rating} {date}'.format(
             type=self.type,
             partner=self.partner.name,
@@ -835,6 +839,7 @@ def activity_to_active_side_effects(i, old_instance=None, user=None):
     pass
 
 
+@python_2_unicode_compatible
 class Agreement(TimeStampedModel):
     """
     Represents an agreement with the partner organization.
@@ -936,7 +941,7 @@ class Agreement(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return'{} for {} ({} - {})'.format(
             self.agreement_type,
             self.partner.name,
@@ -1068,6 +1073,7 @@ class Agreement(TimeStampedModel):
         return super(Agreement, self).save()
 
 
+@python_2_unicode_compatible
 class AgreementAmendment(TimeStampedModel):
     '''
     Represents an amendment to an agreement
@@ -1098,7 +1104,7 @@ class AgreementAmendment(TimeStampedModel):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return "{} {}".format(
             self.agreement.reference_number,
             self.number
@@ -1150,6 +1156,7 @@ def side_effect_two(i, old_instance=None, user=None):
     pass
 
 
+@python_2_unicode_compatible
 class Intervention(TimeStampedModel):
     """
     Represents a partner intervention.
@@ -1310,7 +1317,7 @@ class Intervention(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}'.format(
             self.number
         )
@@ -1550,6 +1557,7 @@ class Intervention(TimeStampedModel):
         super(Intervention, self).save()
 
 
+@python_2_unicode_compatible
 class InterventionAmendment(TimeStampedModel):
     """
     Represents an amendment for the partner intervention.
@@ -1616,7 +1624,7 @@ class InterventionAmendment(TimeStampedModel):
             self.intervention.save(amendment_number=self.amendment_number)
         return super(InterventionAmendment, self).save(**kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}:- {}'.format(
             self.amendment_number,
             self.signed_date
@@ -1644,6 +1652,7 @@ class InterventionPlannedVisits(models.Model):
         unique_together = ('intervention', 'year')
 
 
+@python_2_unicode_compatible
 class InterventionResultLink(models.Model):
     intervention = models.ForeignKey(Intervention, related_name='result_links')
     cp_output = models.ForeignKey(Result, related_name='intervention_links')
@@ -1651,7 +1660,7 @@ class InterventionResultLink(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return '{} {}'.format(
             self.intervention, self.cp_output
         )
@@ -1710,6 +1719,7 @@ class InterventionBudget(TimeStampedModel):
         )
 
 
+@python_2_unicode_compatible
 class FileType(models.Model):
     """
     Represents a file type
@@ -1735,10 +1745,11 @@ class FileType(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class InterventionAttachment(TimeStampedModel):
     """
     Represents a file for the partner intervention
@@ -1759,7 +1770,7 @@ class InterventionAttachment(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return self.attachment.name
 
 
@@ -1778,6 +1789,7 @@ class GovernmentInterventionManager(models.Manager):
 
 
 # TODO: check this for sanity
+@python_2_unicode_compatible
 class GovernmentIntervention(models.Model):
     """
     Represents a government intervention.
@@ -1805,7 +1817,7 @@ class GovernmentIntervention(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return 'Number: {}'.format(self.number) if self.number else \
             '{}: {}'.format(self.pk, self.reference_number)
 
@@ -1841,6 +1853,7 @@ def activity_default():
     return {}
 
 
+@python_2_unicode_compatible
 class GovernmentInterventionResult(models.Model):
     """
     Represents an result from government intervention.
@@ -1898,7 +1911,7 @@ class GovernmentInterventionResult(models.Model):
 
         super(GovernmentInterventionResult, self).save(**kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}, {}'.format(self.intervention.number, self.result)
 
 
@@ -1977,6 +1990,7 @@ class SupplyPlan(models.Model):
     tracker = FieldTracker()
 
 
+@python_2_unicode_compatible
 class DistributionPlan(models.Model):
     """
     Represents a distribution plan for the partner intervention
@@ -2009,7 +2023,7 @@ class DistributionPlan(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}-{}-{}-{}'.format(
             self.intervention,
             self.item,
@@ -2096,6 +2110,7 @@ class DirectCashTransfer(models.Model):
 
 
 # TODO: remove these models
+@python_2_unicode_compatible
 class PCA(AdminURLMixin, models.Model):
     """
     Represents a partner intervention.
@@ -2255,7 +2270,7 @@ class PCA(AdminURLMixin, models.Model):
         verbose_name_plural = 'Old Interventions'
         ordering = ['-created_at']
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}: {}'.format(
             self.partner.name,
             self.number if self.number else self.reference_number
@@ -2528,6 +2543,7 @@ class PCA(AdminURLMixin, models.Model):
         #             commit.save()
 
 
+@python_2_unicode_compatible
 class RAMIndicator(models.Model):
     """
     Represents a RAM Indicator for the partner intervention
@@ -2560,13 +2576,14 @@ class RAMIndicator(models.Model):
     def target(self):
         return self.indicator.target
 
-    def __unicode__(self):
+    def __str__(self):
         return '{} -> {}'.format(
             self.result.sector.name if self.result.sector else '',
             unicode(self.result),
         )
 
 
+@python_2_unicode_compatible
 class AmendmentLog(TimeStampedModel):
     """
     Represents an amendment log for the partner intervention.
@@ -2593,7 +2610,7 @@ class AmendmentLog(TimeStampedModel):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}: {} - {}'.format(
             self.amendment_number,
             self.type,
@@ -2626,6 +2643,7 @@ def get_file_path(instance, filename):
     )
 
 
+@python_2_unicode_compatible
 class PCAFile(models.Model):
     """
     Represents a file for the partner intervention
@@ -2643,7 +2661,7 @@ class PCAFile(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.attachment.name
 
     def download_url(self):
@@ -2655,6 +2673,7 @@ class PCAFile(models.Model):
     download_url.short_description = 'Download Files'
 
 
+@python_2_unicode_compatible
 class PCAGrant(TimeStampedModel):
     """
     Represents a grant for the partner intervention, which links a grant to a partnership with a specified amount
@@ -2678,13 +2697,14 @@ class PCAGrant(TimeStampedModel):
     class Meta:
         ordering = ['-funds']
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}: {}'.format(
             self.grant,
             self.funds
         )
 
 
+@python_2_unicode_compatible
 class GwPCALocation(models.Model):
     """
     Represents a location for the partner intervention, which links a location to a partnership
@@ -2708,7 +2728,7 @@ class GwPCALocation(models.Model):
     class Meta:
         verbose_name = 'Partnership Location'
 
-    def __unicode__(self):
+    def __str__(self):
         return unicode(self.location) if self.location else ''
 
     def view_location(self):
@@ -2717,6 +2737,7 @@ class GwPCALocation(models.Model):
     view_location.short_description = 'View Location'
 
 
+@python_2_unicode_compatible
 class PCASector(TimeStampedModel):
     """
     Represents a sector for the partner intervention, which links a sector to a partnership
@@ -2739,7 +2760,7 @@ class PCASector(TimeStampedModel):
     class Meta:
         verbose_name = 'PCA Sector'
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}: {}: {}'.format(
             self.pca.partner.name,
             self.pca.number,
@@ -2787,6 +2808,7 @@ class IndicatorDueDates(models.Model):
         ordering = ['-due_date']
 
 
+@python_2_unicode_compatible
 class PartnershipBudget(TimeStampedModel):
     """
     Represents a budget for the intervention
@@ -2830,13 +2852,14 @@ class PartnershipBudget(TimeStampedModel):
 
         super(PartnershipBudget, self).save(**kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}: {}'.format(
             self.partnership,
             self.total
         )
 
 
+@python_2_unicode_compatible
 class AgreementAmendmentLog(TimeStampedModel):
     """
     Represents an amendment log for the partner agreement.
@@ -2869,7 +2892,7 @@ class AgreementAmendmentLog(TimeStampedModel):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}: {} - {}'.format(
             self.amendment_number,
             self.type,
@@ -2888,6 +2911,7 @@ class AgreementAmendmentLog(TimeStampedModel):
         return objects.index(self.id) + 1 if self.id in objects else len(objects) + 1
 
 
+@python_2_unicode_compatible
 class AuthorizedOfficer(models.Model):
     # TODO: write a script to move this to authorized officers on the model
     # TODO: change on admin to use the model
@@ -2912,7 +2936,7 @@ class AuthorizedOfficer(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return unicode(self.officer)
 
     @classmethod

--- a/EquiTrack/partners/tests/test_models.py
+++ b/EquiTrack/partners/tests/test_models.py
@@ -1,13 +1,47 @@
 import datetime
 import json
-from unittest import skip
-from actstream.models import model_stream
+import sys
+from unittest import skip, skipIf, TestCase
 
+from django.core.files.uploadedfile import SimpleUploadedFile
 from django.utils import timezone
+
+from actstream.models import model_stream
+import mock
 
 from EquiTrack.stream_feed.actions import create_snapshot_activity_stream
 from EquiTrack.tests.mixins import FastTenantTestCase as TenantTestCase
-from EquiTrack.factories import PartnershipFactory, AgreementFactory, InterventionFactory, InterventionBudgetFactory
+from EquiTrack.factories import (
+    AgreementAmendmentFactory,
+    AgreementFactory,
+    AssessmentFactory,
+    AuthorizedOfficerFactory,
+    DistributionPlanFactory,
+    DonorFactory,
+    FileTypeFactory,
+    GovernmentInterventionFactory,
+    GovernmentInterventionResultFactory,
+    GrantFactory,
+    GwPCALocationFactory,
+    InterventionAmendmentFactory,
+    InterventionAttachmentFactory,
+    InterventionBudgetFactory,
+    InterventionFactory,
+    InterventionResultLinkFactory,
+    LocationFactory,
+    PartnerFactory,
+    PartnershipBudgetFactory,
+    PartnershipFactory,
+    PartnerStaffFactory,
+    PCAFactory,
+    PCAFileFactory,
+    PCAGrantFactory,
+    PCASectorFactory,
+    RAMIndicatorFactory,
+    ResultFactory,
+    SupplyItemFactory,
+    WorkspaceFileTypeFactory,
+    )
 
 from funds.models import Donor, Grant
 
@@ -749,3 +783,266 @@ class TestInterventionModel(TenantTestCase):
             in_kind_amount_local=10,
         )
         self.assertEqual(int(self.intervention.planned_cash_transfers), 15000)
+
+
+@skipIf(sys.version_info.major == 3, "This test can be deleted under Python 3")
+class TestStrUnicode(TestCase):
+    '''Ensure calling str() on model instances returns UTF8-encoded text and unicode() returns unicode.
+
+    AmendmentLog and AgreementAmendmentLog are not tested for two reasons. First, their __str__() methods only use
+    fields like dates and integers, so there's no way to force them to handle non-ASCII. Second, they involve database
+    access which doesn't work with this test because it is a simple (and fast) TestCase rather than a TenantTestCase.
+    '''
+    def test_workspace_file_type(self):
+        instance = WorkspaceFileTypeFactory.build(name=b'xyz')
+        self.assertEqual(str(instance), b'xyz')
+        self.assertEqual(unicode(instance), u'xyz')
+
+        instance = WorkspaceFileTypeFactory.build(name=u'R\xe4dda Barnen')
+        self.assertEqual(str(instance), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(instance), u'R\xe4dda Barnen')
+
+    def test_partner_organization(self):
+        instance = PartnerFactory.build(name=b'xyz')
+        self.assertEqual(str(instance), b'xyz')
+        self.assertEqual(unicode(instance), u'xyz')
+
+        instance = PartnerFactory.build(name=u'R\xe4dda Barnen')
+        self.assertEqual(str(instance), b'R\xc3\xa4dda Barnen')
+        self.assertEqual(unicode(instance), u'R\xe4dda Barnen')
+
+    def test_partner_staff_member(self):
+        partner = PartnerFactory.build(name=b'partner')
+
+        instance = PartnerStaffFactory.build(first_name=b'xyz', partner=partner)
+        self.assertTrue(str(instance).startswith(b'xyz'))
+        self.assertTrue(unicode(instance).startswith(u'xyz'))
+
+        instance = PartnerStaffFactory.build(first_name=u'R\xe4dda Barnen', partner=partner)
+        self.assertTrue(str(instance).startswith(b'R\xc3\xa4dda Barnen'))
+        self.assertTrue(unicode(instance).startswith(u'R\xe4dda Barnen'))
+
+    def test_assessment(self):
+        partner = PartnerFactory.build(name=b'xyz')
+        instance = AssessmentFactory.build(partner=partner)
+        self.assertIn(b'xyz', str(instance))
+        self.assertIn(u'xyz', unicode(instance))
+
+        partner = PartnerFactory.build(name=u'R\xe4dda Barnen')
+        instance = AssessmentFactory.build(partner=partner)
+        self.assertIn(b'R\xc3\xa4dda Barnen', str(instance))
+        self.assertIn(u'R\xe4dda Barnen', unicode(instance))
+
+    def test_agreement(self):
+        partner = PartnerFactory.build(name=b'xyz')
+        instance = AgreementFactory.build(partner=partner)
+        self.assertIn(b'xyz', str(instance))
+        self.assertIn(u'xyz', unicode(instance))
+
+        partner = PartnerFactory.build(name=u'R\xe4dda Barnen')
+        instance = AgreementFactory.build(partner=partner)
+        self.assertIn(b'R\xc3\xa4dda Barnen', str(instance))
+        self.assertIn(u'R\xe4dda Barnen', unicode(instance))
+
+    @mock.patch('partners.models.connection')
+    def test_agreement_amendment(self, mock_connection):
+        # During the __str__() method, connection.tenant.country_short_code gets accessed. Since this is only a
+        # TestCase (not a FastTenantTestCase), attempting to access that raises AttributeError. Rather than slowing
+        # this test down by making it a FastTenantTestCase, I just mock connection.tenant.country_short_code.
+        mock_connection.tenant = mock.Mock()
+        mock_connection.tenant.country_short_code = mock.Mock(return_value='ZZ')
+
+        partner = PartnerFactory.build(name=b'xyz')
+        agreement = AgreementFactory.build(partner=partner)
+        instance = AgreementAmendmentFactory.build(number=b'xyz', agreement=agreement)
+        self.assertIn(b'xyz', str(instance))
+        self.assertIn(u'xyz', unicode(instance))
+
+        instance = AgreementAmendmentFactory.build(number=u'tv\xe5', agreement=agreement)
+        self.assertIn(b'tv\xc3\xa5', str(instance))
+        self.assertIn(u'tv\xe5', unicode(instance))
+
+    def test_intervention(self):
+        instance = InterventionFactory.build(number=b'two')
+        self.assertEqual(b'two', str(instance))
+        self.assertEqual(u'two', unicode(instance))
+
+        instance = InterventionFactory.build(number=u'tv\xe5')
+        self.assertEqual(b'tv\xc3\xa5', str(instance))
+        self.assertEqual(u'tv\xe5', unicode(instance))
+
+    def test_intervention_amendment(self):
+        instance = InterventionAmendmentFactory.build()
+        # This model's __str__() method contains only formatted integers, so it's not possible to challenge it
+        # with non-ASCII text. As long as str() and unicode() succeed, that's all the testing we can do.
+        str(instance)
+        unicode(instance)
+
+    def test_intervention_result_link(self):
+        intervention = InterventionFactory.build(number=b'two')
+        instance = InterventionResultLinkFactory.build(intervention=intervention)
+        self.assertTrue(str(instance).startswith(b'two'))
+        self.assertTrue(unicode(instance).startswith(u'two'))
+
+        intervention = InterventionFactory.build(number=u'tv\xe5')
+        instance = InterventionResultLinkFactory.build(intervention=intervention)
+        self.assertTrue(str(instance).startswith(b'tv\xc3\xa5'))
+        self.assertTrue(unicode(instance).startswith(u'tv\xe5'))
+
+    def test_intervention_budget(self):
+        intervention = InterventionFactory.build(number=b'two')
+        instance = InterventionBudgetFactory.build(intervention=intervention)
+        self.assertTrue(str(instance).startswith(b'two'))
+        self.assertTrue(unicode(instance).startswith(u'two'))
+
+        intervention = InterventionFactory.build(number=u'tv\xe5')
+        instance = InterventionBudgetFactory.build(intervention=intervention)
+        self.assertTrue(str(instance).startswith(b'tv\xc3\xa5'))
+        self.assertTrue(unicode(instance).startswith(u'tv\xe5'))
+
+    def test_file_type(self):
+        instance = FileTypeFactory.build()
+        # This model's __str__() method contains model constants, so it's not possible to challenge it
+        # with non-ASCII text. As long as str() and unicode() succeed, that's all the testing we can do.
+        str(instance)
+        unicode(instance)
+
+    def test_intervention_attachment(self):
+        attachment = SimpleUploadedFile(b'two.txt', u'hello world!'.encode('utf-8'))
+        instance = InterventionAttachmentFactory.build(attachment=attachment)
+        self.assertEqual(str(instance), b'two.txt')
+        self.assertEqual(unicode(instance), u'two.txt')
+
+        attachment = SimpleUploadedFile(u'tv\xe5.txt', u'hello world!'.encode('utf-8'))
+        instance = InterventionAttachmentFactory.build(attachment=attachment)
+        self.assertEqual(str(instance), b'tv\xc3\xa5.txt')
+        self.assertEqual(unicode(instance), u'tv\xe5.txt')
+
+    def test_government_intervention(self):
+        instance = GovernmentInterventionFactory.build(number=b'two')
+        self.assertIn(b'two', str(instance))
+        self.assertIn(u'two', unicode(instance))
+
+        instance = GovernmentInterventionFactory.build(number=u'tv\xe5')
+        self.assertIn(b'tv\xc3\xa5', str(instance))
+        self.assertIn(u'tv\xe5', unicode(instance))
+
+    def test_government_intervention_result(self):
+        government_intervention = GovernmentInterventionFactory.build(number=b'two')
+        instance = GovernmentInterventionResultFactory.build(intervention=government_intervention)
+        self.assertIn(b'two', str(instance))
+        self.assertIn(u'two', unicode(instance))
+
+        government_intervention = GovernmentInterventionFactory.build(number=u'tv\xe5')
+        instance = GovernmentInterventionResultFactory.build(intervention=government_intervention)
+        self.assertIn(b'tv\xc3\xa5', str(instance))
+        self.assertIn(u'tv\xe5', unicode(instance))
+
+    def test_distribution_plan(self):
+        supply_item = SupplyItemFactory.build(name=b'two')
+        instance = DistributionPlanFactory.build(intervention=None, item=supply_item)
+        self.assertTrue(str(instance).startswith(b'None-two-'))
+        self.assertTrue(unicode(instance).startswith(u'None-two-'))
+
+        supply_item = SupplyItemFactory.build(name=u'tv\xe5')
+        instance = DistributionPlanFactory.build(intervention=None, item=supply_item)
+        self.assertTrue(str(instance).startswith(b'None-tv\xc3\xa5-'))
+        self.assertTrue(unicode(instance).startswith(u'None-tv\xe5-'))
+
+    def test_pca(self):
+        partner_organization = PartnerFactory.build(name=b'xyz')
+        instance = PCAFactory.build(partner=partner_organization, number='42')
+        self.assertEqual(str(instance), b'xyz: 42')
+        self.assertEqual(unicode(instance), u'xyz: 42')
+
+        partner_organization = PartnerFactory.build(name=u'R\xe4dda Barnen')
+        instance = PCAFactory.build(partner=partner_organization, number='42')
+        self.assertEqual(str(instance), b'R\xc3\xa4dda Barnen: 42')
+        self.assertEqual(unicode(instance), u'R\xe4dda Barnen: 42')
+
+    def test_ram_indicator(self):
+        result = ResultFactory.build(name=b'xyz')
+        instance = RAMIndicatorFactory.build(result=result)
+        self.assertTrue(str(instance).endswith(b'xyz'))
+        self.assertTrue(unicode(instance).endswith(u'xyz'))
+
+        result = ResultFactory.build(name=u'R\xe4dda Barnen')
+        instance = RAMIndicatorFactory.build(result=result)
+        self.assertTrue(str(instance).endswith(b'R\xc3\xa4dda Barnen'))
+        self.assertTrue(unicode(instance).endswith(u'R\xe4dda Barnen'))
+
+    def test_pca_file(self):
+        attachment = SimpleUploadedFile(b'two.txt', u'hello world!'.encode('utf-8'))
+        instance = PCAFileFactory.build(attachment=attachment)
+        self.assertEqual(str(instance), b'two.txt')
+        self.assertEqual(unicode(instance), u'two.txt')
+
+        attachment = SimpleUploadedFile(u'tv\xe5.txt', u'hello world!'.encode('utf-8'))
+        instance = PCAFileFactory.build(attachment=attachment)
+        self.assertEqual(str(instance), b'tv\xc3\xa5.txt')
+        self.assertEqual(unicode(instance), u'tv\xe5.txt')
+
+    def test_pca_grant(self):
+        donor = DonorFactory.build(name=b'xyz')
+        grant = GrantFactory.build(donor=donor, name=b'xyz')
+        instance = PCAGrantFactory.build(grant=grant)
+        self.assertEqual(str(instance), b'xyz: xyz: None')
+        self.assertEqual(unicode(instance), u'xyz: xyz: None')
+
+        donor = DonorFactory.build(name=u'R\xe4dda Barnen')
+        grant = GrantFactory.build(donor=donor, name=u'R\xe4dda Barnen')
+        instance = PCAGrantFactory.build(grant=grant)
+        self.assertEqual(str(instance), b'R\xc3\xa4dda Barnen: R\xc3\xa4dda Barnen: None')
+        self.assertEqual(unicode(instance), u'R\xe4dda Barnen: R\xe4dda Barnen: None')
+
+    def test_gw_pca_location(self):
+        location = LocationFactory.build(name=b'xyz')
+        instance = GwPCALocationFactory.build(location=location)
+        self.assertTrue(str(instance).startswith(b'xyz'))
+        self.assertTrue(unicode(instance).startswith(u'xyz'))
+
+        location = LocationFactory.build(name=u'Rzesz\xf3w')
+        instance = GwPCALocationFactory.build(location=location)
+        self.assertTrue(str(instance).startswith(b'Rzesz\xc3\xb3w'))
+        self.assertTrue(unicode(instance).startswith(u'Rzesz\xf3w'))
+
+    def test_pca_sector(self):
+        partner_organization = PartnerFactory.build(name=b'xyz')
+        pca = PCAFactory.build(partner=partner_organization)
+        instance = PCASectorFactory.build(pca=pca)
+        self.assertTrue(str(instance).startswith(b'xyz: '))
+        self.assertTrue(unicode(instance).startswith(u'xyz: '))
+
+        partner_organization = PartnerFactory.build(name=u'R\xe4dda Barnen')
+        pca = PCAFactory.build(partner=partner_organization)
+        instance = PCASectorFactory.build(pca=pca)
+        self.assertTrue(str(instance).startswith(b'R\xc3\xa4dda Barnen: '))
+        self.assertTrue(unicode(instance).startswith(u'R\xe4dda Barnen: '))
+
+    def test_partnership_budget(self):
+        partner_organization = PartnerFactory.build(name=b'xyz')
+        pca = PCAFactory.build(partner=partner_organization, number='42')
+        instance = PartnershipBudgetFactory.build(partnership=pca)
+        self.assertTrue(str(instance).startswith(b'xyz: '))
+        self.assertTrue(unicode(instance).startswith(u'xyz: '))
+
+        partner_organization = PartnerFactory.build(name=u'R\xe4dda Barnen')
+        pca = PCAFactory.build(partner=partner_organization, number='42')
+        instance = PartnershipBudgetFactory.build(partnership=pca)
+        self.assertTrue(str(instance).startswith(b'R\xc3\xa4dda Barnen: '))
+        self.assertTrue(unicode(instance).startswith(u'R\xe4dda Barnen: '))
+
+    def test_authorized_officer(self):
+        partner_organization = PartnerFactory.build(name=b'xyz')
+        officer = PartnerStaffFactory.build(partner=partner_organization,
+                                            first_name=b'Boleslaw', last_name=b'the Brave')
+        instance = AuthorizedOfficerFactory.build(officer=officer)
+        self.assertEqual(str(instance), b'Boleslaw the Brave (xyz)')
+        self.assertEqual(unicode(instance), u'Boleslaw the Brave (xyz)')
+
+        partner_organization = PartnerFactory.build(name=u'R\xe4dda Barnen')
+        officer = PartnerStaffFactory.build(partner=partner_organization,
+                                            first_name=u'Boles\u0142aw', last_name=u'the Brave')
+        instance = AuthorizedOfficerFactory.build(officer=officer)
+        self.assertEqual(str(instance), b'Boles\xc5\x82aw the Brave (R\xc3\xa4dda Barnen)')
+        self.assertEqual(unicode(instance), u'Boles\u0142aw the Brave (R\xe4dda Barnen)')


### PR DESCRIPTION
Add `@python_2_unicode_compatible` decorator to all 24 models in partners that had a `__unicode__()` method. (03f4d1eac0ed2d0e67b8089760ad14670a686f5e)

Add tests that use non-ASCII to challenge the `__str__()/__unicode__()` methods of all partners models that have those methods. Added lots of factories to support those tests. Lightly reorganized the imports in `test_models.py` to conform with the 4 sections rule (python/django/3rd party/project). (48f71a359dd9bc9c7f11e8a6c1f44a1cde853ace)

I recently added [EquiTrack/tests/test_all_models.py](https://github.com/unicef/etools/blob/develop/EquiTrack/EquiTrack/tests/test_all_models.py) to ensure that all eTools models eventually implement `@python_2_unicode_compatible`. The idea was that as I implemented it for each app (funds, partners, etc.) that I would also change `test_all_models.py` to include that app in its tests. However, while doing the work for this PR I realized that the code in `test_all_models.py` isn't robust enough to handle the variety of models in `partners`, so `test_all_models.py` needs an update. I will commit that in a separate PR, though, because this one is already long.

This is part of https://github.com/unicef/etools-issues/issues/746
