### PR TITLE
Replace deprecated assertion methods with preferred alternatives

### DIFF
--- a/EquiTrack/audit/tests/test_views.py
+++ b/EquiTrack/audit/tests/test_views.py
@@ -21,7 +21,7 @@ class BaseTestCategoryRisksViewSet(EngagementTransitionsTestCaseMixin):
             user=self.auditor
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('results', response.data)
         self.assertTrue(isinstance(response.data['results'], list))
 
@@ -94,10 +94,10 @@ class BaseTestCategoryRisksViewSet(EngagementTransitionsTestCaseMixin):
                 field_name: category_dict
             }
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         new_risk_ids = list(self.engagement.risks.values_list('id', flat=True))
-        self.assertNotEquals(new_risk_ids, old_risk_ids)
+        self.assertNotEqual(new_risk_ids, old_risk_ids)
 
     def _update_unexisted_blueprint(self, field_name, category_code, allowed_user):
         category = RiskCategoryFactory(code=category_code)
@@ -122,7 +122,7 @@ class BaseTestCategoryRisksViewSet(EngagementTransitionsTestCaseMixin):
             user=allowed_user,
             data=data
         )
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def _test_category_update_by_user_without_permissions(self, category_code, field_name, not_allowed):
         old_risk_ids = list(self.engagement.risks.values_list('id', flat=True))
@@ -156,7 +156,7 @@ class BaseTestCategoryRisksViewSet(EngagementTransitionsTestCaseMixin):
         )
 
         new_risk_ids = list(self.engagement.risks.values_list('id', flat=True))
-        self.assertEquals(new_risk_ids, old_risk_ids)
+        self.assertEqual(new_risk_ids, old_risk_ids)
 
 
 class TestMARisksViewSet(BaseTestCategoryRisksViewSet, APITenantTestCase):
@@ -230,7 +230,7 @@ class TestEngagementsListViewSet(EngagementTransitionsTestCaseMixin, APITenantTe
             '/api/audit/engagements/',
             user=user
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIn('results', response.data)
         self.assertIsInstance(response.data['results'], list)
         self.assertListEqual(
@@ -263,7 +263,7 @@ class TestAuditorFirmViewSet(AuditTestCaseMixin, APITenantTestCase):
             user=user
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertListEqual(
             sorted(map(lambda x: x['id'], response.data['results'])),
             sorted(map(lambda x: x.id, expected_firms))
@@ -286,14 +286,14 @@ class TestAuditorStaffMembersViewSet(AuditTestCaseMixin, APITenantTestCase):
             '/api/audit/audit-firms/{0}/staff-members/'.format(self.auditor_firm.id),
             user=self.unicef_focal_point
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.forced_auth_req(
             'get',
             '/api/audit/audit-firms/{0}/staff-members/'.format(self.auditor_firm.id),
             user=self.usual_user
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_detail_view(self):
         response = self.forced_auth_req(
@@ -304,7 +304,7 @@ class TestAuditorStaffMembersViewSet(AuditTestCaseMixin, APITenantTestCase):
             ),
             user=self.unicef_focal_point
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.forced_auth_req(
             'get',
@@ -314,7 +314,7 @@ class TestAuditorStaffMembersViewSet(AuditTestCaseMixin, APITenantTestCase):
             ),
             user=self.usual_user
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_create_view(self):
         response = self.forced_auth_req(
@@ -332,7 +332,7 @@ class TestAuditorStaffMembersViewSet(AuditTestCaseMixin, APITenantTestCase):
             },
             user=self.unicef_focal_point
         )
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
 
         response = self.forced_auth_req(
             'post',
@@ -349,7 +349,7 @@ class TestAuditorStaffMembersViewSet(AuditTestCaseMixin, APITenantTestCase):
             },
             user=self.usual_user
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_update_view(self):
         response = self.forced_auth_req(
@@ -366,7 +366,7 @@ class TestAuditorStaffMembersViewSet(AuditTestCaseMixin, APITenantTestCase):
             },
             user=self.unicef_focal_point
         )
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
 
         response = self.forced_auth_req(
             'patch',
@@ -382,7 +382,7 @@ class TestAuditorStaffMembersViewSet(AuditTestCaseMixin, APITenantTestCase):
             },
             user=self.usual_user
         )
-        self.assertEquals(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
 
 class TestEngagementPDFExportViewSet(EngagementTransitionsTestCaseMixin, APITenantTestCase):
@@ -395,7 +395,7 @@ class TestEngagementPDFExportViewSet(EngagementTransitionsTestCaseMixin, APITena
             user=user
         )
 
-        self.assertEquals(response.status_code, status_code)
+        self.assertEqual(response.status_code, status_code)
         if status_code == status.HTTP_200_OK:
             self.assertIn(response._headers['content-disposition'][0], 'Content-Disposition')
 

--- a/EquiTrack/partners/tests/test_api_interventions.py
+++ b/EquiTrack/partners/tests/test_api_interventions.py
@@ -210,14 +210,14 @@ class TestInterventionsAPI(APITenantTestCase):
 
         self.assertEqual(status_code, status.HTTP_201_CREATED)
         self.assertItemsEqual(response['frs'], frs_data)
-        self.assertEquals(response['frs_details']['total_actual_amt'],
-                          float(sum([self.fr_1.actual_amt, self.fr_2.actual_amt])))
-        self.assertEquals(response['frs_details']['total_outstanding_amt'],
-                          float(sum([self.fr_1.outstanding_amt, self.fr_2.outstanding_amt])))
-        self.assertEquals(response['frs_details']['total_frs_amt'],
-                          float(sum([self.fr_1.total_amt, self.fr_2.total_amt])))
-        self.assertEquals(response['frs_details']['total_intervention_amt'],
-                          float(sum([self.fr_1.intervention_amt, self.fr_2.intervention_amt])))
+        self.assertEqual(response['frs_details']['total_actual_amt'],
+                         float(sum([self.fr_1.actual_amt, self.fr_2.actual_amt])))
+        self.assertEqual(response['frs_details']['total_outstanding_amt'],
+                         float(sum([self.fr_1.outstanding_amt, self.fr_2.outstanding_amt])))
+        self.assertEqual(response['frs_details']['total_frs_amt'],
+                         float(sum([self.fr_1.total_amt, self.fr_2.total_amt])))
+        self.assertEqual(response['frs_details']['total_intervention_amt'],
+                         float(sum([self.fr_1.intervention_amt, self.fr_2.intervention_amt])))
 
     def test_add_two_valid_frs_on_update_pd(self):
         frs_data = [self.fr_1.id, self.fr_2.id]
@@ -228,14 +228,14 @@ class TestInterventionsAPI(APITenantTestCase):
 
         self.assertEqual(status_code, status.HTTP_200_OK)
         self.assertItemsEqual(response['frs'], frs_data)
-        self.assertEquals(response['frs_details']['total_actual_amt'],
-                          float(sum([self.fr_1.actual_amt, self.fr_2.actual_amt])))
-        self.assertEquals(response['frs_details']['total_outstanding_amt'],
-                          float(sum([self.fr_1.outstanding_amt, self.fr_2.outstanding_amt])))
-        self.assertEquals(response['frs_details']['total_frs_amt'],
-                          float(sum([self.fr_1.total_amt, self.fr_2.total_amt])))
-        self.assertEquals(response['frs_details']['total_intervention_amt'],
-                          float(sum([self.fr_1.intervention_amt, self.fr_2.intervention_amt])))
+        self.assertEqual(response['frs_details']['total_actual_amt'],
+                         float(sum([self.fr_1.actual_amt, self.fr_2.actual_amt])))
+        self.assertEqual(response['frs_details']['total_outstanding_amt'],
+                         float(sum([self.fr_1.outstanding_amt, self.fr_2.outstanding_amt])))
+        self.assertEqual(response['frs_details']['total_frs_amt'],
+                         float(sum([self.fr_1.total_amt, self.fr_2.total_amt])))
+        self.assertEqual(response['frs_details']['total_intervention_amt'],
+                         float(sum([self.fr_1.intervention_amt, self.fr_2.intervention_amt])))
 
     def test_remove_an_fr_from_pd(self):
         frs_data = [self.fr_1.id, self.fr_2.id]
@@ -309,7 +309,7 @@ class TestInterventionsAPI(APITenantTestCase):
 
     def test_permissions_for_intervention_status_draft(self):
         # intervention is in Draft status
-        self.assertEquals(self.intervention.status, Intervention.DRAFT)
+        self.assertEqual(self.intervention.status, Intervention.DRAFT)
 
         # user is UNICEF User
         status_code, response = self.run_request(self.intervention.id, user=self.partnership_manager_user)
@@ -327,7 +327,7 @@ class TestInterventionsAPI(APITenantTestCase):
     @skip('add test after permissions file is ready')
     def test_permissions_for_intervention_status_active(self):
         # intervention is in Draft status
-        self.assertEquals(self.active_intervention.status, Intervention.ACTIVE)
+        self.assertEqual(self.active_intervention.status, Intervention.ACTIVE)
 
         # user is UNICEF User
         status_code, response = self.run_request(self.active_intervention.id, user=self.partnership_manager_user)
@@ -347,7 +347,7 @@ class TestInterventionsAPI(APITenantTestCase):
             status_code, response = self.run_request_list_ep(user=self.unicef_staff, method='get')
 
         self.assertEqual(status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response), 3)
+        self.assertEqual(len(response), 3)
 
         # add another intervention to make sure that the queries are constant
         data = {
@@ -365,4 +365,4 @@ class TestInterventionsAPI(APITenantTestCase):
             status_code, response = self.run_request_list_ep(user=self.unicef_staff, method='get')
 
         self.assertEqual(status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response), 4)
+        self.assertEqual(len(response), 4)

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -100,7 +100,7 @@ class TestPartnerOrganizationListView(APITenantTestCase):
         if expected_keys is None:
             expected_keys = self.normal_field_names
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.rendered_content)
         self.assertIsInstance(response_json, list)
         self.assertEqual(len(response_json), 1)
@@ -158,7 +158,7 @@ class TestPartnerOrganizationListView(APITenantTestCase):
         }
         response = self.forced_auth_req('get', self.url, data=params)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.rendered_content)
         self.assertIsInstance(response_json, list)
         self.assertEqual(len(response_json), 0)
@@ -189,7 +189,7 @@ class TestPartnerOrganizationListView(APITenantTestCase):
 
         response = self.forced_auth_req('get', self.url, data={"values": "{},{},{}".format(p1.id, p2.id, unused_id)})
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.rendered_content)
         self.assertIsInstance(response_json, list)
         self.assertEqual(len(response_json), 2)
@@ -203,7 +203,7 @@ class TestPartnerOrganizationListView(APITenantTestCase):
     def test_values_negative(self):
         '''Ensure that garbage values are handled properly'''
         response = self.forced_auth_req('get', self.url, data={"values": "banana"})
-        self.assertEquals(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
 class TestPartnerOrganizationListViewForCSV(APITenantTestCase):
@@ -238,7 +238,7 @@ class TestPartnerOrganizationListViewForCSV(APITenantTestCase):
         '''
         self.assertFalse(self.wrapper_called)
         response = self.forced_auth_req('get', self.url, data={"format": "csv"})
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         # Ensure my wrapper was called, which tells me that the proper serializer was invoked.
         self.assertTrue(self.wrapper_called)
 
@@ -265,7 +265,7 @@ class TestPartnerOrganizationListViewForCSV(APITenantTestCase):
         '''Exercise passing an unrecognized format.'''
         # This returns 404, it should probably return 400 but anything in the 4xx series gets the point across.
         response = self.forced_auth_req('get', self.url, data={"format": "banana"})
-        self.assertEquals(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
 
 class TestPartnerOrganizationCreateView(APITenantTestCase):
@@ -276,7 +276,7 @@ class TestPartnerOrganizationCreateView(APITenantTestCase):
 
     def assertResponseFundamentals(self, response):
         '''Assert common fundamentals about the response. Return the id of the new object.'''
-        self.assertEquals(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
         response_json = json.loads(response.rendered_content)
         self.assertIsInstance(response_json, dict)
         self.assertIn('id', response_json.keys())
@@ -872,7 +872,7 @@ class TestAgreementAPIFileAttachments(APITenantTestCase):
             user=self.partnership_manager_user,
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         response_json = json.loads(response.rendered_content)
         self.assertIsInstance(response_json, dict)
 
@@ -1030,7 +1030,7 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
         response_json = json.loads(response.rendered_content)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         for r in response_json:
             self.assertEqual(r['end'], self.country_programme.to_date.isoformat())
 
@@ -1043,7 +1043,7 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
         response_json = json.loads(response.rendered_content)
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
         for r in response_json:
             self.assertEqual(r['end'], self.country_programme.to_date.isoformat())
 
@@ -1187,7 +1187,7 @@ class TestAgreementAPIView(APITenantTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data), 2)
-        # self.assertEquals(response.data[1]["agreement_number"], self.agreement.agreement_number)
+        # self.assertEqual(response.data[1]["agreement_number"], self.agreement.agreement_number)
 
     def test_agreements_update_set_to_active_on_save(self):
         '''Ensure that a draft agreement auto-transitions to signed when saved with signing info'''
@@ -1289,7 +1289,7 @@ class TestAgreementAPIView(APITenantTestCase):
             data=data
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data["amendments"][1]["types"]), 2)
+        self.assertEqual(len(response.data["amendments"][1]["types"]), 2)
 
 
 class TestPartnerStaffMemberAPIView(APITenantTestCase):

--- a/EquiTrack/t2f/tests/test_dashboard.py
+++ b/EquiTrack/t2f/tests/test_dashboard.py
@@ -53,7 +53,7 @@ class TravelActivityList(APITenantTestCase):
         act.partner = partner
         act.save()
 
-        self.assertEquals(act.primary_traveler, act.travels.first().traveler)
+        self.assertEqual(act.primary_traveler, act.travels.first().traveler)
 
         with self.assertNumQueries(4):
             response = self.forced_auth_req('get', reverse('t2f:travels:list:activities',

--- a/EquiTrack/users/tests/test_views.py
+++ b/EquiTrack/users/tests/test_views.py
@@ -202,8 +202,8 @@ class TestUserViewsV3(APITenantTestCase):
     def test_api_users_list(self):
         response = self.forced_auth_req('get', '/api/v3/users/', user=self.unicef_staff)
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
     def test_users_api_list_values(self):
         response = self.forced_auth_req(
@@ -234,8 +234,8 @@ class TestUserViewsV3(APITenantTestCase):
             data={"partnership_managers": True}
         )
 
-        self.assertEquals(response.status_code, status.HTTP_200_OK)
-        self.assertEquals(len(response.data), 2)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 2)
 
     def test_api_users_retrieve_myprofile(self):
         response = self.forced_auth_req(


### PR DESCRIPTION
`assertEquals()` and `assertNotEquals()` were deprecated in Python 2.7.
https://docs.python.org/2/library/unittest.html#deprecated-aliases

This commit changes all instances of these two assertions to their non-deprecated versions (`assertEqual()` and `assertNotEqual()`). No functional change.

I used an automated tool to do this --
```
find backend/EquiTrack -name "*.py" | xargs 2to3 -w -n -f asserts
```

I already cleaned these up in #724 but new ones have snuck back in since then.