### PR TITLE
API endpoints for retreiving and updating Disaggregations

### DIFF
--- a/EquiTrack/partners/tests/test_api_prp.py
+++ b/EquiTrack/partners/tests/test_api_prp.py
@@ -13,7 +13,7 @@ from EquiTrack.factories import (
     LocationFactory,
     ResultFactory,
     UserFactory,
-    )
+)
 from EquiTrack.tests.mixins import APITenantTestCase
 from partners.models import InterventionResultLink
 from partners.permissions import READ_ONLY_API_GROUP_NAME
@@ -26,23 +26,7 @@ class TestInterventionsAPI(APITenantTestCase):
 
     def setUp(self):
         super(TestInterventionsAPI, self).setUp()
-        setup_intervention_test_data(self)
-        # setup data specific to PRP API
-        self.result = ResultFactory(name='A Result')
-        self.result_link = InterventionResultLink.objects.create(
-            intervention=self.active_intervention, cp_output=self.result)
-        self.lower_result = LowerResult.objects.create(result_link=self.result_link, name='Lower Result 1')
-        self.indicator_blueprint = IndicatorBlueprint.objects.create(
-            title='The Blueprint'
-        )
-        self.applied_indicator = AppliedIndicator.objects.create(
-            indicator=self.indicator_blueprint,
-            lower_result=self.lower_result,
-        )
-        self.applied_indicator.locations.add(LocationFactory(name='A Location',
-                                                             gateway=GatewayTypeFactory(name='A Gateway'),
-                                                             p_code='a-p-code'))
-        self.applied_indicator.disaggregation.create(name='A Disaggregation')
+        setup_intervention_test_data(self, include_results_and_indicators=True)
 
     def run_prp_v1(self, user=None, method='get'):
         response = self.forced_auth_req(

--- a/EquiTrack/partners/tests/test_utils.py
+++ b/EquiTrack/partners/tests/test_utils.py
@@ -39,7 +39,7 @@ def setup_intervention_test_data(test_case, include_results_and_indicators=False
         partner_authorized_officer_signatory=test_case.partner1.staff_members.all().first()
     )
 
-    test_case.result_type = ResultType.objects.get(name=ResultType.OUTPUT)
+    test_case.result_type = ResultType.objects.get_or_create(name=ResultType.OUTPUT)[0]
     test_case.result = ResultFactory(result_type=test_case.result_type)
 
     # TODO intervention sector locations cleanup

--- a/EquiTrack/partners/tests/test_utils.py
+++ b/EquiTrack/partners/tests/test_utils.py
@@ -1,12 +1,13 @@
 import datetime
 from EquiTrack.factories import UserFactory, GroupFactory, PartnerFactory, AgreementFactory, InterventionFactory, \
-    ResultFactory, FundsReservationHeaderFactory
+    ResultFactory, FundsReservationHeaderFactory, LocationFactory, GatewayTypeFactory
 # TODO intervention sector locations cleanup
-from partners.models import Intervention, InterventionSectorLocationLink, InterventionBudget
-from reports.models import ResultType, Sector
+from partners.models import Intervention, InterventionSectorLocationLink, InterventionBudget, \
+    InterventionResultLink
+from reports.models import ResultType, Sector, LowerResult, IndicatorBlueprint, AppliedIndicator
 
 
-def setup_intervention_test_data(test_case):
+def setup_intervention_test_data(test_case, include_results_and_indicators=False):
     today = datetime.date.today()
     test_case.unicef_staff = UserFactory(is_staff=True)
     test_case.partnership_manager_user = UserFactory(is_staff=True)
@@ -63,3 +64,23 @@ def setup_intervention_test_data(test_case):
     # set up two frs not connected to any interventions
     test_case.fr_1 = FundsReservationHeaderFactory(intervention=None)
     test_case.fr_2 = FundsReservationHeaderFactory(intervention=None)
+    if include_results_and_indicators:
+        # setup additional inicator/results
+        test_case.result = ResultFactory(name='A Result')
+        test_case.result_link = InterventionResultLink.objects.create(
+            intervention=test_case.active_intervention, cp_output=test_case.result)
+        test_case.lower_result = LowerResult.objects.create(result_link=test_case.result_link,
+                                                            name='Lower Result 1')
+        test_case.indicator_blueprint = IndicatorBlueprint.objects.create(
+            title='The Blueprint'
+        )
+        test_case.applied_indicator = AppliedIndicator.objects.create(
+            indicator=test_case.indicator_blueprint,
+            lower_result=test_case.lower_result,
+        )
+        test_case.applied_indicator.locations.add(LocationFactory(
+            name='A Location',
+            gateway=GatewayTypeFactory(name='A Gateway'),
+            p_code='a-p-code')
+        )
+        test_case.disaggregation = test_case.applied_indicator.disaggregation.create(name='A Disaggregation')

--- a/EquiTrack/reports/serializers/v2.py
+++ b/EquiTrack/reports/serializers/v2.py
@@ -85,9 +85,11 @@ class DisaggregationSerializer(serializers.ModelSerializer):
         except KeyError:
             pass
         else:
+            found_values = []
             for value_data in values_data:
                 value_id = value_data.get('id', None)
                 if value_id:
+                    found_values.append(value_id)
                     try:
                         value = DisaggregationValue.objects.get(disaggregation=instance, id=value_id)
                         for k, v in value_data.items():
@@ -100,7 +102,10 @@ class DisaggregationSerializer(serializers.ModelSerializer):
                             )
                         )
                 else:
-                    DisaggregationValue.objects.create(disaggregation=instance, **value_data)
+                    value = DisaggregationValue.objects.create(disaggregation=instance, **value_data)
+                    found_values.append(value.id)
+            # delete any values that weren't specified
+            instance.disaggregation_values.exclude(id__in=found_values).delete()
         return super(DisaggregationSerializer, self).update(instance, validated_data)
 
 

--- a/EquiTrack/reports/serializers/v2.py
+++ b/EquiTrack/reports/serializers/v2.py
@@ -80,6 +80,10 @@ class DisaggregationSerializer(serializers.ModelSerializer):
         return disaggregation
 
     def update(self, instance, validated_data):
+        if instance.applied_indicators.count():
+            raise ValidationError(
+                'You cannot update a Disaggregation that is already associated with an Indicator.'
+            )
         try:
             values_data = validated_data.pop('disaggregation_values')
         except KeyError:

--- a/EquiTrack/reports/serializers/v2.py
+++ b/EquiTrack/reports/serializers/v2.py
@@ -88,10 +88,17 @@ class DisaggregationSerializer(serializers.ModelSerializer):
             for value_data in values_data:
                 value_id = value_data.get('id', None)
                 if value_id:
-                    value = DisaggregationValue.objects.get(id=value_id)
-                    for k, v in value_data.items():
-                        setattr(value, k, v)
-                    value.save()
+                    try:
+                        value = DisaggregationValue.objects.get(disaggregation=instance, id=value_id)
+                        for k, v in value_data.items():
+                            setattr(value, k, v)
+                        value.save()
+                    except DisaggregationValue.DoesNotExist:
+                        raise ValidationError(
+                            "Tried to modify DisaggregationValue {} that is not associated with {}".format(
+                                value_id, instance,
+                            )
+                        )
                 else:
                     DisaggregationValue.objects.create(disaggregation=instance, **value_data)
         return super(DisaggregationSerializer, self).update(instance, validated_data)

--- a/EquiTrack/reports/serializers/v2.py
+++ b/EquiTrack/reports/serializers/v2.py
@@ -73,8 +73,9 @@ class DisaggregationSerializer(serializers.ModelSerializer):
         disaggregation = Disaggregation.objects.create(**validated_data)
         for value_data in values_data:
             if 'id' in value_data:
-                # todo: is this valid? silently create new DisaggregationValues if IDs are passed in
-                del value_data['id']
+                raise ValidationError(
+                    "You are not allowed to specify DisaggregationValues IDs when creating a new Disaggregation"
+                )
             DisaggregationValue.objects.create(disaggregation=disaggregation, **value_data)
         return disaggregation
 

--- a/EquiTrack/reports/serializers/v2.py
+++ b/EquiTrack/reports/serializers/v2.py
@@ -79,16 +79,20 @@ class DisaggregationSerializer(serializers.ModelSerializer):
         return disaggregation
 
     def update(self, instance, validated_data):
-        values_data = validated_data.pop('disaggregation_values')
-        for value_data in values_data:
-            value_id = value_data.get('id', None)
-            if value_id:
-                value = DisaggregationValue.objects.get(id=value_id)
-                for k, v in value_data.items():
-                    setattr(value, k, v)
-                value.save()
-            else:
-                DisaggregationValue.objects.create(disaggregation=instance, **value_data)
+        try:
+            values_data = validated_data.pop('disaggregation_values')
+        except KeyError:
+            pass
+        else:
+            for value_data in values_data:
+                value_id = value_data.get('id', None)
+                if value_id:
+                    value = DisaggregationValue.objects.get(id=value_id)
+                    for k, v in value_data.items():
+                        setattr(value, k, v)
+                    value.save()
+                else:
+                    DisaggregationValue.objects.create(disaggregation=instance, **value_data)
         return super(DisaggregationSerializer, self).update(instance, validated_data)
 
 

--- a/EquiTrack/reports/tests/test_serializers.py
+++ b/EquiTrack/reports/tests/test_serializers.py
@@ -41,9 +41,11 @@ class DisaggregationTest(FastTenantTestCase):
             'active': self.disaggregation.active,
             'disaggregation_values': [
                 {
+                    'id': value_1.id,
                     'value': value_1.value,
                     'active': value_1.active,
                 }, {
+                    'id': value_2.id,
                     'value': value_2.value,
                     'active': value_2.active,
                 }

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -280,6 +280,9 @@ class TestDisaggregationRetrieveUpdateViews(APITenantTestCase):
         })
         response = self.forced_auth_req('put', self._get_url(disaggregation), data=data)
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        # also try with patch
+        response = self.forced_auth_req('patch', self._get_url(disaggregation), data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
     def test_delete(self):
         """

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -244,7 +244,7 @@ class TestDisaggregationRetrieveUpdateViews(APITenantTestCase):
 
     def test_create_values(self):
         """
-        Test updating a disaggregation's values
+        Test creating new disaggregation values
         """
         disaggregation = DisaggregationFactory()
         value = DisaggregationValueFactory(disaggregation=disaggregation)
@@ -259,3 +259,12 @@ class TestDisaggregationRetrieveUpdateViews(APITenantTestCase):
         self.assertEqual(2, disaggregation.disaggregation_values.count())
         new_value = disaggregation.disaggregation_values.exclude(pk=value.pk)[0]
         self.assertEqual('a new value', new_value.value)
+
+    def test_delete(self):
+        """
+        Test deleting a disaggregation is not allowed
+        """
+        disaggregation = DisaggregationFactory()
+        response = self.forced_auth_req('delete', self._get_url(disaggregation))
+        self.assertEqual(response.status_code, status.HTTP_405_METHOD_NOT_ALLOWED)
+        self.assertTrue(Disaggregation.objects.filter(pk=disaggregation.pk).exists())

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -213,6 +213,18 @@ class TestDisaggregationRetrieveUpdateViews(APITenantTestCase):
         disaggregation = Disaggregation.objects.get(pk=disaggregation.pk)
         self.assertEqual(new_name, disaggregation.name)
 
+    def test_patch_metadata(self):
+        """
+        Test patching a disaggregation's metadata
+        """
+        disaggregation = DisaggregationFactory()
+        new_name = 'patched via API'
+        response = self.forced_auth_req('patch', self._get_url(disaggregation),
+                                        data={'name': new_name})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        disaggregation = Disaggregation.objects.get(pk=disaggregation.pk)
+        self.assertEqual(new_name, disaggregation.name)
+
     def test_update_values(self):
         """
         Test updating a disaggregation's values

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -270,6 +270,17 @@ class TestDisaggregationRetrieveUpdateViews(APITenantTestCase):
         new_value = disaggregation.disaggregation_values.exclude(pk=value.pk)[0]
         self.assertEqual('a new value', new_value.value)
 
+    def test_disallow_modifying_unrelated_disaggregation_values(self):
+        disaggregation = DisaggregationFactory()
+        value = DisaggregationValueFactory()
+        data = DisaggregationSerializer(instance=disaggregation).data
+        data['disaggregation_values'].append({
+            "id": value.pk,
+            "value": "not allowed",
+        })
+        response = self.forced_auth_req('put', self._get_url(disaggregation), data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
     def test_delete(self):
         """
         Test deleting a disaggregation is not allowed

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -174,6 +174,16 @@ class TestDisaggregationListCreateViews(APITenantTestCase):
         self.assertEqual(disaggregation.name, 'Gender')
         self.assertEqual(disaggregation.disaggregation_values.count(), 3)
 
+    def test_create_disallows_value_ids(self):
+        data = {
+            'name': 'Gender',
+            'disaggregation_values': [
+                {'id': 999, 'value': 'Female'},
+            ]
+        }
+        response = self.forced_auth_req('post', self.url, data=data)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
 
 class TestDisaggregationRetrieveUpdateViews(APITenantTestCase):
     """

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -9,7 +9,7 @@ from EquiTrack.factories import (
     ResultFactory,
     CountryProgrammeFactory,
     DisaggregationFactory,
-)
+    DisaggregationValueFactory)
 from EquiTrack.tests.mixins import APITenantTestCase
 
 
@@ -135,7 +135,7 @@ class TestReportViews(APITenantTestCase):
         self.assertIn(self.result1.id, [int(i["id"]) for i in response.data])
 
 
-class TestDisaggregationViews(APITenantTestCase):
+class TestDisaggregationListCreateViews(APITenantTestCase):
     """
     Very minimal testing, just to make sure things work.
     """
@@ -172,3 +172,30 @@ class TestDisaggregationViews(APITenantTestCase):
         disaggregation = Disaggregation.objects.get()
         self.assertEqual(disaggregation.name, 'Gender')
         self.assertEqual(disaggregation.disaggregation_values.count(), 3)
+
+
+class TestDisaggregationRetrieveUpdateViews(APITenantTestCase):
+    """
+    Very minimal testing, just to make sure things work.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = UserFactory(is_staff=True)
+
+    @staticmethod
+    def _get_url(dissagregation):
+        return reverse('disaggregation-retrieve-update', args=[dissagregation.pk])
+
+    def test_get(self):
+        """
+        Test retrieving a single disaggregation
+        """
+        disaggregation = DisaggregationFactory()
+        num_values = 3
+        for i in range(num_values):
+            DisaggregationValueFactory(disaggregation=disaggregation)
+        response = self.forced_auth_req('get', self._get_url(disaggregation))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(disaggregation.name, response.data['name'])
+        self.assertEqual(num_values, len(response.data['disaggregation_values']))

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -4,8 +4,7 @@ from django.core.urlresolvers import reverse
 from rest_framework import status
 from partners.tests.test_utils import setup_intervention_test_data
 
-from reports.models import ResultType, CountryProgramme, Disaggregation, DisaggregationValue, IndicatorBlueprint, \
-    AppliedIndicator
+from reports.models import ResultType, CountryProgramme, Disaggregation, DisaggregationValue
 from EquiTrack.factories import (
     UserFactory,
     ResultFactory,

--- a/EquiTrack/reports/urls_v2.py
+++ b/EquiTrack/reports/urls_v2.py
@@ -1,7 +1,7 @@
 from django.conf.urls import url
 
 from reports.views.v2 import OutputListAPIView, OutputDetailAPIView, ResultIndicatorListAPIView, \
-    LowerResultsDeleteView, DisaggregationListCreateView
+    LowerResultsDeleteView, DisaggregationListCreateView, DisaggregationRetrieveUpdateView
 from reports.views.v1 import CountryProgrammeListView, CountryProgrammeRetrieveView
 
 
@@ -20,4 +20,6 @@ urlpatterns = (
         name='result-indicator-list'),
     url(r'reports/disaggregations/$', view=DisaggregationListCreateView.as_view(),
         name='disaggregation-list-create'),
+    url(r'reports/disaggregations/(?P<pk>\d+)/$', view=DisaggregationRetrieveUpdateView.as_view(),
+        name='disaggregation-retrieve-update'),
 )

--- a/EquiTrack/reports/views/v2.py
+++ b/EquiTrack/reports/views/v2.py
@@ -3,7 +3,8 @@ import operator
 
 from django.db.models import Q
 from rest_framework.exceptions import ValidationError
-from rest_framework.generics import ListAPIView, RetrieveAPIView, DestroyAPIView, ListCreateAPIView
+from rest_framework.generics import ListAPIView, RetrieveAPIView, DestroyAPIView, ListCreateAPIView, \
+    RetrieveUpdateAPIView
 from rest_framework.permissions import IsAdminUser
 from rest_framework.response import Response
 from rest_framework import status
@@ -121,5 +122,10 @@ class LowerResultsDeleteView(DestroyAPIView):
 
 
 class DisaggregationListCreateView(ListCreateAPIView):
+    serializer_class = DisaggregationSerializer
+    queryset = Disaggregation.objects.all()
+
+
+class DisaggregationRetrieveUpdateView(RetrieveUpdateAPIView):
     serializer_class = DisaggregationSerializer
     queryset = Disaggregation.objects.all()


### PR DESCRIPTION
Took a crack at what I thought these two items meant:

- Endpoint for getting/patching/deleting disaggregations (disabled deleting)
- Test endpoint for getting/patching/deleting disaggregations

@robertavram cc @vkurup since you wrote the other Disaggregations endpoint / tests.