### PR TITLE
Add workspace id to partners api

### DIFF
--- a/EquiTrack/EquiTrack/tests/mixins.py
+++ b/EquiTrack/EquiTrack/tests/mixins.py
@@ -178,3 +178,16 @@ class APITenantTestCase(FastTenantTestCase):
             response.render()
 
         return response
+
+
+class WorkspaceRequiredAPITestMixIn(object):
+    """
+    For APITenantTestCases that have a required workspace param, just automatically
+    set the current tenant.
+    """
+    def forced_auth_req(self, method, url, user=None, data=None, request_format='json', **kwargs):
+        data = data or {}
+        data['workspace'] = self.tenant.business_area_code
+        return super(WorkspaceRequiredAPITestMixIn, self).forced_auth_req(
+            method, url, user=user, data=data, request_format=request_format, **kwargs
+        )

--- a/EquiTrack/partners/tests/test_api_prp.py
+++ b/EquiTrack/partners/tests/test_api_prp.py
@@ -14,14 +14,14 @@ from EquiTrack.factories import (
     ResultFactory,
     UserFactory,
 )
-from EquiTrack.tests.mixins import APITenantTestCase
+from EquiTrack.tests.mixins import APITenantTestCase, WorkspaceRequiredAPITestMixIn
 from partners.models import InterventionResultLink
 from partners.permissions import READ_ONLY_API_GROUP_NAME
 from partners.tests.test_utils import setup_intervention_test_data
 from reports.models import LowerResult, AppliedIndicator, IndicatorBlueprint
 
 
-class TestInterventionsAPI(APITenantTestCase):
+class TestInterventionsAPI(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     fixtures = ['initial_data.json']
 
     def setUp(self):
@@ -33,7 +33,6 @@ class TestInterventionsAPI(APITenantTestCase):
             method,
             reverse('prp_api_v1:prp-intervention-list'),
             user=user or self.unicef_staff,
-            data={'workspace': self.tenant.business_area_code},
         )
         return response.status_code, json.loads(response.rendered_content)
 

--- a/EquiTrack/partners/tests/test_exports.py
+++ b/EquiTrack/partners/tests/test_exports.py
@@ -7,13 +7,13 @@ from tablib.core import Dataset
 from EquiTrack.factories import UserFactory, PartnerFactory, AgreementFactory, \
     GovernmentInterventionFactory, InterventionFactory, CountryProgrammeFactory, ResultFactory, \
     InterventionBudgetFactory, PartnerStaffFactory
-from EquiTrack.tests.mixins import APITenantTestCase
+from EquiTrack.tests.mixins import APITenantTestCase, WorkspaceRequiredAPITestMixIn
 from publics.tests.factories import CurrencyFactory
 from partners.models import GovernmentInterventionResult
 from reports.models import ResultType
 
 
-class TestModelExport(APITenantTestCase):
+class TestModelExport(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     def setUp(self):
         super(TestModelExport, self).setUp()
         self.unicef_staff = UserFactory(is_staff=True)

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -739,7 +739,6 @@ class TestPartnerOrganizationRetrieveUpdateDeleteViews(APITenantTestCase):
         self.assertEqual(response.data["hidden"], False)
 
 
-
 class TestPartnershipViews(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     fixtures = ['initial_data.json']
 

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -242,7 +242,7 @@ class TestAPIPartnerOrganizationListView(WorkspaceRequiredAPITestMixIn, APITenan
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class TestPartnerOrganizationListViewForCSV(APITenantTestCase):
+class TestPartnerOrganizationListViewForCSV(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     '''Exercise the CSV-generating portion of the list view for PartnerOrganization.
 
     This is a separate test case from TestPartnerOrganizationListView because it does some monkey patching in
@@ -739,7 +739,8 @@ class TestPartnerOrganizationRetrieveUpdateDeleteViews(APITenantTestCase):
         self.assertEqual(response.data["hidden"], False)
 
 
-class TestPartnershipViews(APITenantTestCase):
+
+class TestPartnershipViews(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     fixtures = ['initial_data.json']
 
     def setUp(self):

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -34,7 +34,7 @@ from EquiTrack.factories import (
     SectionFactory,
     UserFactory,
 )
-from EquiTrack.tests.mixins import APITenantTestCase, URLAssertionMixin
+from EquiTrack.tests.mixins import APITenantTestCase, URLAssertionMixin, WorkspaceRequiredAPITestMixIn
 from reports.models import ResultType
 from users.models import Country
 from funds.models import FundsCommitmentItem, FundsCommitmentHeader
@@ -81,7 +81,7 @@ class URLsTestCase(URLAssertionMixin, TestCase):
         self.assertIntParamRegexes(names_and_paths, 'partners_api:')
 
 
-class TestAPIPartnerOrganizationListView(APITenantTestCase):
+class TestAPIPartnerOrganizationListView(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     '''Exercise the list view for PartnerOrganization'''
     def setUp(self):
         self.user = UserFactory(is_staff=True)

--- a/EquiTrack/partners/views/helpers.py
+++ b/EquiTrack/partners/views/helpers.py
@@ -16,6 +16,3 @@ def set_tenant_or_fail(workspace):
             raise ValidationError('Workspace code provided is not a valid business_area_code: %s' % workspace)
         else:
             connection.set_tenant(ws)
-
-
-

--- a/EquiTrack/partners/views/helpers.py
+++ b/EquiTrack/partners/views/helpers.py
@@ -1,0 +1,21 @@
+from django.db import connection
+from rest_framework.exceptions import ValidationError
+from users.models import Country
+
+
+def set_tenant_or_fail(workspace):
+    """
+    Sets the tenant for a workspace (Country) or raises a ValidationError if not able to
+    """
+    if workspace is None:
+        raise ValidationError('Workspace is required as a queryparam')
+    else:
+        try:
+            ws = Country.objects.get(business_area_code=workspace)
+        except Country.DoesNotExist:
+            raise ValidationError('Workspace code provided is not a valid business_area_code: %s' % workspace)
+        else:
+            connection.set_tenant(ws)
+
+
+

--- a/EquiTrack/partners/views/partner_organization_v2.py
+++ b/EquiTrack/partners/views/partner_organization_v2.py
@@ -38,6 +38,7 @@ from partners.serializers.partner_organization_v2 import (
     AssessmentDetailSerializer,
     MinimalPartnerOrganizationListSerializer,
 )
+from partners.views.helpers import set_tenant_or_fail
 from t2f.models import TravelActivity
 from partners.permissions import PartnershipManagerRepPermission, PartnershipManagerPermission
 from partners.filters import PartnerScopeFilter
@@ -74,6 +75,8 @@ class PartnerOrganizationListAPIView(ListCreateAPIView):
     def get_queryset(self, format=None):
         q = PartnerOrganization.objects.all()
         query_params = self.request.query_params
+        workspace = query_params.get('workspace', None)
+        set_tenant_or_fail(workspace)
 
         if query_params:
             queries = []

--- a/EquiTrack/partners/views/prp_v1.py
+++ b/EquiTrack/partners/views/prp_v1.py
@@ -2,9 +2,7 @@ import functools
 import operator
 
 from django.db.models import Q
-from django.db import connection
 
-from rest_framework.exceptions import ValidationError
 from rest_framework.generics import (
     ListAPIView)
 
@@ -14,7 +12,7 @@ from partners.models import (
 )
 from partners.serializers.prp_v1 import PRPInterventionListSerializer
 from partners.permissions import ListCreateAPIMixedPermission
-from users.models import Country as Workspace
+from partners.views.helpers import set_tenant_or_fail
 
 
 class PRPInterventionListAPIView(ListAPIView):
@@ -41,15 +39,7 @@ class PRPInterventionListAPIView(ListAPIView):
 
         query_params = self.request.query_params
         workspace = query_params.get('workspace', None)
-        if workspace is None:
-            raise ValidationError('Workspace is required as a queryparam')
-        else:
-            try:
-                ws = Workspace.objects.get(business_area_code=workspace)
-            except Workspace.DoesNotExist:
-                raise ValidationError('Workspace code provided is not a valid business_area_code: %s' % workspace)
-            else:
-                connection.set_tenant(ws)
+        set_tenant_or_fail(workspace)
 
         if query_params:
             queries = []


### PR DESCRIPTION
Implements the first box of https://github.com/unicef/etools/issues/934 (was already implemented for the intervention api)