### PR TITLE
add pagination and filtering to prp API

### DIFF
--- a/EquiTrack/EquiTrack/tests/mixins.py
+++ b/EquiTrack/EquiTrack/tests/mixins.py
@@ -92,7 +92,7 @@ class FastTenantTestCase(TenantTestCase):
         TenantModel = get_tenant_model()
         try:
             cls.tenant = TenantModel.objects.get(domain_url=tenant_domain, schema_name='test')
-        except:
+        except TenantModel.DoesNotExist:
             cls.tenant = TenantModel(domain_url=tenant_domain, schema_name='test')
             cls.tenant.save(verbosity=0)
 

--- a/EquiTrack/EquiTrack/tests/mixins.py
+++ b/EquiTrack/EquiTrack/tests/mixins.py
@@ -178,3 +178,16 @@ class APITenantTestCase(FastTenantTestCase):
             response.render()
 
         return response
+
+
+class WorkspaceRequiredAPITestMixIn(object):
+    """
+    For APITenantTestCases that have a required workspace param, just automatically
+    set the current tenant.
+    """
+    def forced_auth_req(self, method, url, user=None, data=None, request_format='json', **kwargs):
+        data = data or {}
+        data['workspace'] = self.tenant.business_area_code
+        return super(WorkspaceRequiredAPITestMixIn, self).forced_auth_req(
+            method, url, user=user, data=data, request_format=request_format, **kwargs
+        )

--- a/EquiTrack/partners/serializers/prp_v1.py
+++ b/EquiTrack/partners/serializers/prp_v1.py
@@ -150,6 +150,7 @@ class PRPInterventionListSerializer(serializers.ModelSerializer):
                                               max_digits=20, decimal_places=2)
     funds_received_currency = serializers.CharField(source='fr_currency', read_only=True)
     expected_results = PRPResultSerializer(many=True, read_only=True, source='all_lower_results')
+    update_date = serializers.DateTimeField(source='modified')
 
     def get_business_area_code(self, obj):
         return connection.tenant.business_area_code
@@ -170,4 +171,5 @@ class PRPInterventionListSerializer(serializers.ModelSerializer):
             'funds_received', 'funds_received_currency',
             # 'reporting_frequencies',  # todo: figure out where this comes from
             'expected_results',
+            'update_date'
         )

--- a/EquiTrack/partners/tests/data/prp-intervention-list.json
+++ b/EquiTrack/partners/tests/data/prp-intervention-list.json
@@ -53,7 +53,8 @@
     "funds_received_currency": null,
     "cso_budget_currency": null,
     "id": 642,
-    "cso_budget": null
+    "cso_budget": null,
+    "update_date": "2017-10-12T08:10:43.708677Z"
   },
   {
     "expected_results": [],
@@ -77,7 +78,8 @@
     "funds_received_currency": null,
     "cso_budget_currency": null,
     "id": 641,
-    "cso_budget": null
+    "cso_budget": null,
+    "update_date": "2017-10-12T08:10:43.708677Z"
   },
   {
     "expected_results": [],
@@ -101,6 +103,7 @@
     "funds_received_currency": null,
     "cso_budget_currency": null,
     "id": 640,
-    "cso_budget": "200.00"
+    "cso_budget": "200.00",
+    "update_date": "2017-10-12T08:10:43.708677Z"
   }
 ]

--- a/EquiTrack/partners/tests/test_api_prp.py
+++ b/EquiTrack/partners/tests/test_api_prp.py
@@ -43,6 +43,7 @@ class TestInterventionsAPI(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
             user=self.unicef_staff, method='get'
         )
         self.assertEqual(status_code, status.HTTP_200_OK)
+        response = response['results']
 
         # uncomment if you need to see the response json / regenerate the test file
         # print json.dumps(response, indent=2)
@@ -85,10 +86,10 @@ class TestInterventionsAPI(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
                 user=self.unicef_staff, method='get', data=params
             )
             self.assertEqual(status_code, status.HTTP_200_OK)
-            self.assertEqual(expected_results, len(response))
+            self.assertEqual(expected_results, len(response['results']))
 
     def test_prp_api_performance(self):
-        EXPECTED_QUERIES = 18
+        EXPECTED_QUERIES = 19
         with self.assertNumQueries(EXPECTED_QUERIES):
             self.run_prp_v1(
                 user=self.unicef_staff, method='get'

--- a/EquiTrack/partners/tests/test_api_prp.py
+++ b/EquiTrack/partners/tests/test_api_prp.py
@@ -52,7 +52,7 @@ class TestInterventionsAPI(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
         for i in range(len(response)):
             expected_intervention = expected_interventions[i]
             actual_intervention = response[i]
-            for dynamic_key in ['id', 'number', 'start_date', 'end_date']:
+            for dynamic_key in ['id', 'number', 'start_date', 'end_date', 'update_date']:
                 del expected_intervention[dynamic_key]
                 del actual_intervention[dynamic_key]
             for j in range(len(expected_intervention['expected_results'])):

--- a/EquiTrack/partners/tests/test_api_prp.py
+++ b/EquiTrack/partners/tests/test_api_prp.py
@@ -14,14 +14,14 @@ from EquiTrack.factories import (
     ResultFactory,
     UserFactory,
 )
-from EquiTrack.tests.mixins import APITenantTestCase
+from EquiTrack.tests.mixins import APITenantTestCase, WorkspaceRequiredAPITestMixIn
 from partners.models import InterventionResultLink
 from partners.permissions import READ_ONLY_API_GROUP_NAME
 from partners.tests.test_utils import setup_intervention_test_data
 from reports.models import LowerResult, AppliedIndicator, IndicatorBlueprint
 
 
-class TestInterventionsAPI(APITenantTestCase):
+class TestInterventionsAPI(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     fixtures = ['initial_data.json']
 
     def setUp(self):
@@ -33,7 +33,6 @@ class TestInterventionsAPI(APITenantTestCase):
             method,
             reverse('prp_api_v1:prp-intervention-list'),
             user=user or self.unicef_staff,
-            data={'workspace': self.tenant.business_area_code},
         )
         return response.status_code, json.loads(response.rendered_content)
 

--- a/EquiTrack/partners/tests/test_exports.py
+++ b/EquiTrack/partners/tests/test_exports.py
@@ -7,13 +7,13 @@ from tablib.core import Dataset
 from EquiTrack.factories import UserFactory, PartnerFactory, AgreementFactory, \
     GovernmentInterventionFactory, InterventionFactory, CountryProgrammeFactory, ResultFactory, \
     InterventionBudgetFactory, PartnerStaffFactory
-from EquiTrack.tests.mixins import APITenantTestCase, WorkspaceRequiredAPITestMixIn
+from EquiTrack.tests.mixins import APITenantTestCase
 from publics.tests.factories import CurrencyFactory
 from partners.models import GovernmentInterventionResult
 from reports.models import ResultType
 
 
-class TestModelExport(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
+class TestModelExport(APITenantTestCase):
     def setUp(self):
         super(TestModelExport, self).setUp()
         self.unicef_staff = UserFactory(is_staff=True)

--- a/EquiTrack/partners/tests/test_exports.py
+++ b/EquiTrack/partners/tests/test_exports.py
@@ -7,13 +7,13 @@ from tablib.core import Dataset
 from EquiTrack.factories import UserFactory, PartnerFactory, AgreementFactory, \
     GovernmentInterventionFactory, InterventionFactory, CountryProgrammeFactory, ResultFactory, \
     InterventionBudgetFactory, PartnerStaffFactory
-from EquiTrack.tests.mixins import APITenantTestCase
+from EquiTrack.tests.mixins import APITenantTestCase, WorkspaceRequiredAPITestMixIn
 from publics.tests.factories import CurrencyFactory
 from partners.models import GovernmentInterventionResult
 from reports.models import ResultType
 
 
-class TestModelExport(APITenantTestCase):
+class TestModelExport(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     def setUp(self):
         super(TestModelExport, self).setUp()
         self.unicef_staff = UserFactory(is_staff=True)

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -776,6 +776,19 @@ class TestPartnershipViews(APITenantTestCase):
         self.assertEqual(len(response.data), 1)
         self.assertIn("Partner", response.data[0]["name"])
 
+    def test_api_partners_list_specify_workspace(self):
+        # specifying current tenant works
+        response = self.forced_auth_req('get', '/api/v2/partners/', user=self.unicef_staff,
+                                        data={'workspace': self.tenant.business_area_code})
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), 1)
+
+        # specifying invalid tenant fails
+        response = self.forced_auth_req('get', '/api/v2/partners/', user=self.unicef_staff,
+                                        data={'workspace': ':('})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+
     @skip("different endpoint")
     def test_api_agreements_list(self):
 

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -739,7 +739,6 @@ class TestPartnerOrganizationRetrieveUpdateDeleteViews(APITenantTestCase):
         self.assertEqual(response.data["hidden"], False)
 
 
-
 class TestPartnershipViews(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     fixtures = ['initial_data.json']
 

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -242,7 +242,7 @@ class TestAPIPartnerOrganizationListView(WorkspaceRequiredAPITestMixIn, APITenan
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class TestPartnerOrganizationListViewForCSV(APITenantTestCase):
+class TestPartnerOrganizationListViewForCSV(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     '''Exercise the CSV-generating portion of the list view for PartnerOrganization.
 
     This is a separate test case from TestPartnerOrganizationListView because it does some monkey patching in
@@ -739,7 +739,8 @@ class TestPartnerOrganizationRetrieveUpdateDeleteViews(APITenantTestCase):
         self.assertEqual(response.data["hidden"], False)
 
 
-class TestPartnershipViews(APITenantTestCase):
+
+class TestPartnershipViews(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     fixtures = ['initial_data.json']
 
     def setUp(self):

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -34,7 +34,7 @@ from EquiTrack.factories import (
     SectionFactory,
     UserFactory,
 )
-from EquiTrack.tests.mixins import APITenantTestCase, URLAssertionMixin
+from EquiTrack.tests.mixins import APITenantTestCase, URLAssertionMixin, WorkspaceRequiredAPITestMixIn
 from reports.models import ResultType
 from users.models import Country
 from funds.models import FundsCommitmentItem, FundsCommitmentHeader
@@ -81,7 +81,7 @@ class URLsTestCase(URLAssertionMixin, TestCase):
         self.assertIntParamRegexes(names_and_paths, 'partners_api:')
 
 
-class TestAPIPartnerOrganizationListView(APITenantTestCase):
+class TestAPIPartnerOrganizationListView(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
     '''Exercise the list view for PartnerOrganization'''
     def setUp(self):
         self.user = UserFactory(is_staff=True)

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -788,7 +788,6 @@ class TestPartnershipViews(APITenantTestCase):
                                         data={'workspace': ':('})
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
-
     @skip("different endpoint")
     def test_api_agreements_list(self):
 

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -34,7 +34,7 @@ from EquiTrack.factories import (
     SectionFactory,
     UserFactory,
 )
-from EquiTrack.tests.mixins import APITenantTestCase, URLAssertionMixin, WorkspaceRequiredAPITestMixIn
+from EquiTrack.tests.mixins import APITenantTestCase, URLAssertionMixin
 from reports.models import ResultType
 from users.models import Country
 from funds.models import FundsCommitmentItem, FundsCommitmentHeader
@@ -81,7 +81,7 @@ class URLsTestCase(URLAssertionMixin, TestCase):
         self.assertIntParamRegexes(names_and_paths, 'partners_api:')
 
 
-class TestAPIPartnerOrganizationListView(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
+class TestAPIPartnerOrganizationListView(APITenantTestCase):
     '''Exercise the list view for PartnerOrganization'''
     def setUp(self):
         self.user = UserFactory(is_staff=True)
@@ -242,7 +242,7 @@ class TestAPIPartnerOrganizationListView(WorkspaceRequiredAPITestMixIn, APITenan
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
 
 
-class TestPartnerOrganizationListViewForCSV(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
+class TestPartnerOrganizationListViewForCSV(APITenantTestCase):
     '''Exercise the CSV-generating portion of the list view for PartnerOrganization.
 
     This is a separate test case from TestPartnerOrganizationListView because it does some monkey patching in
@@ -739,7 +739,7 @@ class TestPartnerOrganizationRetrieveUpdateDeleteViews(APITenantTestCase):
         self.assertEqual(response.data["hidden"], False)
 
 
-class TestPartnershipViews(WorkspaceRequiredAPITestMixIn, APITenantTestCase):
+class TestPartnershipViews(APITenantTestCase):
     fixtures = ['initial_data.json']
 
     def setUp(self):

--- a/EquiTrack/partners/views/helpers.py
+++ b/EquiTrack/partners/views/helpers.py
@@ -16,6 +16,3 @@ def set_tenant_or_fail(workspace):
             raise ValidationError('Workspace code provided is not a valid business_area_code: %s' % workspace)
         else:
             connection.set_tenant(ws)
-
-
-

--- a/EquiTrack/partners/views/helpers.py
+++ b/EquiTrack/partners/views/helpers.py
@@ -1,0 +1,21 @@
+from django.db import connection
+from rest_framework.exceptions import ValidationError
+from users.models import Country
+
+
+def set_tenant_or_fail(workspace):
+    """
+    Sets the tenant for a workspace (Country) or raises a ValidationError if not able to
+    """
+    if workspace is None:
+        raise ValidationError('Workspace is required as a queryparam')
+    else:
+        try:
+            ws = Country.objects.get(business_area_code=workspace)
+        except Country.DoesNotExist:
+            raise ValidationError('Workspace code provided is not a valid business_area_code: %s' % workspace)
+        else:
+            connection.set_tenant(ws)
+
+
+

--- a/EquiTrack/partners/views/partner_organization_v2.py
+++ b/EquiTrack/partners/views/partner_organization_v2.py
@@ -38,6 +38,7 @@ from partners.serializers.partner_organization_v2 import (
     AssessmentDetailSerializer,
     MinimalPartnerOrganizationListSerializer,
 )
+from partners.views.helpers import set_tenant_or_fail
 from t2f.models import TravelActivity
 from partners.permissions import PartnershipManagerRepPermission, PartnershipManagerPermission
 from partners.filters import PartnerScopeFilter
@@ -74,6 +75,8 @@ class PartnerOrganizationListAPIView(ListCreateAPIView):
     def get_queryset(self, format=None):
         q = PartnerOrganization.objects.all()
         query_params = self.request.query_params
+        workspace = query_params.get('workspace', None)
+        set_tenant_or_fail(workspace)
 
         if query_params:
             queries = []

--- a/EquiTrack/partners/views/partner_organization_v2.py
+++ b/EquiTrack/partners/views/partner_organization_v2.py
@@ -76,7 +76,8 @@ class PartnerOrganizationListAPIView(ListCreateAPIView):
         q = PartnerOrganization.objects.all()
         query_params = self.request.query_params
         workspace = query_params.get('workspace', None)
-        set_tenant_or_fail(workspace)
+        if workspace:
+            set_tenant_or_fail(workspace)
 
         if query_params:
             queries = []

--- a/EquiTrack/partners/views/prp_v1.py
+++ b/EquiTrack/partners/views/prp_v1.py
@@ -51,6 +51,10 @@ class PRPInterventionListAPIView(ListAPIView):
                 queries.append(Q(status=query_params.get("status")))
             if "partner" in query_params.keys():
                 queries.append(Q(agreement__partner=query_params.get("partner")))
+            if "updated_before" in query_params.keys():
+                queries.append(Q(modified__lte=query_params.get("updated_before")))
+            if "updated_after" in query_params.keys():
+                queries.append(Q(modified__gte=query_params.get("updated_after")))
             if queries:
                 expression = functools.reduce(operator.and_, queries)
                 q = q.filter(expression).distinct()

--- a/EquiTrack/partners/views/prp_v1.py
+++ b/EquiTrack/partners/views/prp_v1.py
@@ -5,6 +5,7 @@ from django.db.models import Q
 
 from rest_framework.generics import (
     ListAPIView)
+from rest_framework.pagination import PageNumberPagination, LimitOffsetPagination
 
 from partners.filters import PartnerScopeFilter
 from partners.models import (
@@ -15,6 +16,10 @@ from partners.permissions import ListCreateAPIMixedPermission
 from partners.views.helpers import set_tenant_or_fail
 
 
+class PRPInterventionPagination(LimitOffsetPagination):
+    default_limit = 100
+
+
 class PRPInterventionListAPIView(ListAPIView):
     """
     Create new Interventions.
@@ -23,6 +28,10 @@ class PRPInterventionListAPIView(ListAPIView):
     serializer_class = PRPInterventionListSerializer
     permission_classes = (ListCreateAPIMixedPermission, )
     filter_backends = (PartnerScopeFilter,)
+    pagination_class = PRPInterventionPagination
+
+    def paginate_queryset(self, queryset):
+        return super(PRPInterventionListAPIView, self).paginate_queryset(queryset)
 
     def get_queryset(self, format=None):
         q = Intervention.objects.prefetch_related(

--- a/EquiTrack/partners/views/prp_v1.py
+++ b/EquiTrack/partners/views/prp_v1.py
@@ -2,9 +2,7 @@ import functools
 import operator
 
 from django.db.models import Q
-from django.db import connection
 
-from rest_framework.exceptions import ValidationError
 from rest_framework.generics import (
     ListAPIView)
 
@@ -14,7 +12,7 @@ from partners.models import (
 )
 from partners.serializers.prp_v1 import PRPInterventionListSerializer
 from partners.permissions import ListCreateAPIMixedPermission
-from users.models import Country as Workspace
+from partners.views.helpers import set_tenant_or_fail
 
 
 class PRPInterventionListAPIView(ListAPIView):
@@ -41,15 +39,7 @@ class PRPInterventionListAPIView(ListAPIView):
 
         query_params = self.request.query_params
         workspace = query_params.get('workspace', None)
-        if workspace is None:
-            raise ValidationError('Workspace is required as a queryparam')
-        else:
-            try:
-                ws = Workspace.objects.get(business_area_code=workspace)
-            except Workspace.DoesNotExist:
-                raise ValidationError('Workspace code provided is not a valid business_area_code: %s' % workspace)
-            else:
-                connection.set_tenant(ws)
+        set_tenant_or_fail(workspace)
 
         if query_params:
             queries = []

--- a/EquiTrack/partners/views/prp_v1.py
+++ b/EquiTrack/partners/views/prp_v1.py
@@ -56,7 +56,3 @@ class PRPInterventionListAPIView(ListAPIView):
                 q = q.filter(expression).distinct()
 
         return q
-
-    def list(self, request):
-        # todo: customize this (or remove if no customizations needed)
-        return super(PRPInterventionListAPIView, self).list(request)

--- a/EquiTrack/partners/views/prp_v1.py
+++ b/EquiTrack/partners/views/prp_v1.py
@@ -5,7 +5,7 @@ from django.db.models import Q
 
 from rest_framework.generics import (
     ListAPIView)
-from rest_framework.pagination import PageNumberPagination, LimitOffsetPagination
+from rest_framework.pagination import LimitOffsetPagination
 
 from partners.filters import PartnerScopeFilter
 from partners.models import (


### PR DESCRIPTION
this implements pagination and date based filtering/values from https://github.com/unicef/etools/issues/934

It includes everything in https://github.com/unicef/etools/pull/938 so I wouldn't have to deal with merge conflicts, but is separate in case we want to change the pagination format or date params.