### PR TITLE
Refactor planned visits on PartnerOrganization

### DIFF
--- a/EquiTrack/EquiTrack/factories.py
+++ b/EquiTrack/EquiTrack/factories.py
@@ -206,6 +206,13 @@ class InterventionBudgetFactory(factory.django.DjangoModelFactory):
     in_kind_amount_local = 10.00
 
 
+class InterventionPlannedVisitsFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = partner_models.InterventionPlannedVisits
+
+    intervention = factory.SubFactory(InterventionFactory)
+
+
 class ResultTypeFactory(factory.django.DjangoModelFactory):
     class Meta:
         model = report_models.ResultType

--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -535,23 +535,20 @@ class PartnerOrganization(AdminURLMixin, models.Model):
 
     @classmethod
     def planned_visits(cls, partner, pv_intervention=None):
+        """For current year sum all programmatic values of planned visits
+        records for partner
+
+        If partner type is Government, then default to 0 planned visits
+        """
         year = datetime.date.today().year
         # planned visits
-        pv = 0
         if partner.partner_type == 'Government':
-            pass
+            pv = 0
         else:
-            if pv_intervention:
-                pv = InterventionPlannedVisits.objects.filter(
-                    intervention__agreement__partner=partner, year=year,
-                    intervention__status__in=[Intervention.ACTIVE, Intervention.CLOSED, Intervention.ENDED]).exclude(
-                    id=pv_intervention.id).aggregate(models.Sum('programmatic'))['programmatic__sum'] or 0
-                pv += pv_intervention.programmatic
-            else:
-                pv = InterventionPlannedVisits.objects.filter(
-                    intervention__agreement__partner=partner, year=year,
-                    intervention__status__in=[Intervention.ACTIVE, Intervention.CLOSED, Intervention.ENDED]).aggregate(
-                    models.Sum('programmatic'))['programmatic__sum'] or 0
+            pv = InterventionPlannedVisits.objects.filter(
+                intervention__agreement__partner=partner, year=year,
+                intervention__status__in=[Intervention.ACTIVE, Intervention.CLOSED, Intervention.ENDED]).aggregate(
+                models.Sum('programmatic'))['programmatic__sum'] or 0
 
         hact = json.loads(partner.hact_values) if isinstance(partner.hact_values, str) else partner.hact_values
         hact["planned_visits"] = pv
@@ -1621,8 +1618,8 @@ class InterventionPlannedVisits(models.Model):
 
     @transaction.atomic
     def save(self, **kwargs):
-        PartnerOrganization.planned_visits(self.intervention.agreement.partner, self)
         super(InterventionPlannedVisits, self).save(**kwargs)
+        PartnerOrganization.planned_visits(self.intervention.agreement.partner, self)
 
     class Meta:
         unique_together = ('intervention', 'year')

--- a/EquiTrack/partners/tests/test_models.py
+++ b/EquiTrack/partners/tests/test_models.py
@@ -650,6 +650,7 @@ class TestPartnerOrganizationModel(TenantTestCase):
             3
         )
 
+
 class TestAgreementModel(TenantTestCase):
     fixtures = ['initial_data.json']
 

--- a/EquiTrack/partners/tests/test_models.py
+++ b/EquiTrack/partners/tests/test_models.py
@@ -7,7 +7,13 @@ from django.utils import timezone
 
 from EquiTrack.stream_feed.actions import create_snapshot_activity_stream
 from EquiTrack.tests.mixins import FastTenantTestCase as TenantTestCase
-from EquiTrack.factories import PartnershipFactory, AgreementFactory, InterventionFactory, InterventionBudgetFactory
+from EquiTrack.factories import (
+    AgreementFactory,
+    InterventionFactory,
+    InterventionBudgetFactory,
+    InterventionPlannedVisitsFactory,
+    PartnershipFactory,
+)
 
 from funds.models import Donor, Grant
 
@@ -540,64 +546,109 @@ class TestPartnerOrganizationModel(TenantTestCase):
             else self.partner_organization.hact_values
         self.assertEqual(hact['planned_cash_transfer'], 100001)
 
-    @skip('Deprecated functionality -planned visits towards government')
     def test_planned_visits_gov(self):
         self.partner_organization.partner_type = "Government"
         self.partner_organization.save()
-        CountryProgramme.objects.create(
-            name="CP 1",
-            wbs="/A0/",
-            from_date=datetime.date(datetime.date.today().year - 1, 1, 1),
-            to_date=datetime.date(datetime.date.today().year + 1, 1, 1),
+        intervention = InterventionFactory(
+            agreement=self.pca_signed1,
+            status=Intervention.ACTIVE
         )
-        gi = GovernmentIntervention.objects.create(
-            partner=self.partner_organization,
+        year = datetime.date.today().year
+        InterventionPlannedVisitsFactory(
+            intervention=intervention,
+            year=year,
+            programmatic=3
         )
-        rt = ResultType.objects.get(id=1)
-        r = Result.objects.create(
-            result_type=rt,
+        InterventionPlannedVisitsFactory(
+            intervention=intervention,
+            year=year - 1,
+            programmatic=2
         )
-        GovernmentInterventionResult.objects.create(
-            intervention=gi,
-            result=r,
-            year=datetime.date.today().year,
-            planned_visits=3,
-        )
-        GovernmentInterventionResult.objects.create(
-            intervention=gi,
-            result=r,
-            year=datetime.date.today().year,
-            planned_visits=2,
-        )
-        self.assertEqual(self.partner_organization.hact_values['planned_visits'], 5)
+        self.assertEqual(self.partner_organization.hact_values['planned_visits'], 0)
 
-    @skip("Fix when HACT available")
     def test_planned_visits_non_gov(self):
         self.partner_organization.partner_type = "UN Agency"
         self.partner_organization.status = PCA.ACTIVE
         self.partner_organization.save()
-        agreement = Agreement.objects.create(
-            agreement_type=Agreement.PCA,
-            partner=self.partner_organization,
+        intervention = InterventionFactory(
+            agreement=self.pca_signed1,
+            status=Intervention.ACTIVE
         )
-        Intervention.objects.create(
-            title="Int 1",
-            status=PCA.ACTIVE,
-            agreement=agreement,
-            submission_date=datetime.date(datetime.date.today().year, 1, 1),
-            end=datetime.date(datetime.date.today().year + 1, 1, 1),
-            planned_visits=3,
+        year = datetime.date.today().year
+        InterventionPlannedVisitsFactory(
+            intervention=intervention,
+            year=year,
+            programmatic=3
         )
-        Intervention.objects.create(
-            title="Int 1",
-            status=PCA.ACTIVE,
-            agreement=agreement,
-            submission_date=datetime.date(datetime.date.today().year, 1, 1),
-            end=datetime.date(datetime.date.today().year + 1, 1, 1),
-            planned_visits=2,
+        InterventionPlannedVisitsFactory(
+            intervention=intervention,
+            year=year - 1,
+            programmatic=2
         )
-        self.assertEqual(self.partner_organization.hact_values['planned_visits'], 5)
+        self.assertEqual(self.partner_organization.hact_values['planned_visits'], 3)
 
+    def test_planned_visits_non_gov_no_pv_intervention(self):
+        self.partner_organization.partner_type = "UN Agency"
+        self.partner_organization.status = PCA.ACTIVE
+        self.partner_organization.save()
+        intervention1 = InterventionFactory(
+            agreement=self.pca_signed1,
+            status=Intervention.ACTIVE
+        )
+        intervention2 = InterventionFactory(
+            agreement=self.pca_signed1,
+            status=Intervention.ACTIVE
+        )
+        year = datetime.date.today().year
+        InterventionPlannedVisitsFactory(
+            intervention=intervention1,
+            year=year,
+            programmatic=3
+        )
+        InterventionPlannedVisitsFactory(
+            intervention=intervention2,
+            year=year - 1,
+            programmatic=2
+        )
+        PartnerOrganization.planned_visits(
+            self.partner_organization
+        )
+        self.assertEqual(
+            self.partner_organization.hact_values['planned_visits'],
+            3
+        )
+
+    def test_planned_visits_non_gov_with_pv_intervention(self):
+        self.partner_organization.partner_type = "UN Agency"
+        self.partner_organization.status = PCA.ACTIVE
+        self.partner_organization.save()
+        intervention1 = InterventionFactory(
+            agreement=self.pca_signed1,
+            status=Intervention.ACTIVE
+        )
+        intervention2 = InterventionFactory(
+            agreement=self.pca_signed1,
+            status=Intervention.ACTIVE
+        )
+        year = datetime.date.today().year
+        pv = InterventionPlannedVisitsFactory(
+            intervention=intervention1,
+            year=year,
+            programmatic=3
+        )
+        InterventionPlannedVisitsFactory(
+            intervention=intervention2,
+            year=year - 1,
+            programmatic=2
+        )
+        PartnerOrganization.planned_visits(
+            self.partner_organization,
+            pv
+        )
+        self.assertEqual(
+            self.partner_organization.hact_values['planned_visits'],
+            3
+        )
 
 class TestAgreementModel(TenantTestCase):
     fixtures = ['initial_data.json']


### PR DESCRIPTION
Before it appeared that if provided with a planned visit
we would exclude that provided planned visit from the query, and then
add it to the summed result from the query.

This had the side affect of including provided planned visits that
had years for non current years.

It seems simpler to just query all the planned visits for the current year
and sum their programmatic value.