### PR TITLE
Make audit models str method python 2 and 3 compatible

### DIFF
--- a/EquiTrack/EquiTrack/mixins.py
+++ b/EquiTrack/EquiTrack/mixins.py
@@ -1,7 +1,6 @@
 """
 Project wide mixins for models and classes
 """
-import json
 import logging
 
 import jwt

--- a/EquiTrack/EquiTrack/tests/test_all_models.py
+++ b/EquiTrack/EquiTrack/tests/test_all_models.py
@@ -25,7 +25,6 @@ EXCLUDED_PACKAGES = (
 
     # These are the eTools packages that aren't yet using @python_2_unicode_compatible and therefore aren't yet
     # Python 3-compatible. As they're fixed one by one, they'll be removed from this list.
-    'audit',
     'partners',
     't2f',
     'users',

--- a/EquiTrack/audit/models.py
+++ b/EquiTrack/audit/models.py
@@ -45,10 +45,8 @@ class AuditorStaffMember(BaseStaffMember):
     auditor_firm = models.ForeignKey(AuditorFirm, verbose_name=_('firm'), related_name='staff_members')
 
     def __str__(self):
-        return '{} ({})'.format(
-            self.get_full_name(),
-            self.auditor_firm.name
-        )
+        auditor_firm_name = ' ({})'.format(self.auditor_firm.name) if hasattr(self, 'auditor_firm') else ''
+        return self.get_full_name() + auditor_firm_name
 
     def send_user_appointed_email(self, engagement):
         context = {

--- a/EquiTrack/audit/models.py
+++ b/EquiTrack/audit/models.py
@@ -674,6 +674,7 @@ class AuditPermissionQueryset(StatusBasePermissionQueryset):
         return super(AuditPermissionQueryset, self).filter(*args, **kwargs)
 
 
+@python_2_unicode_compatible
 class AuditPermission(StatusBasePermission):
     STATUSES = StatusBasePermission.STATUSES + Engagement.STATUSES
 

--- a/EquiTrack/audit/tests/test_models.py
+++ b/EquiTrack/audit/tests/test_models.py
@@ -1,8 +1,24 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+import sys
+from unittest import skipIf, TestCase
+
 from django.core import mail
 
 from EquiTrack.tests.mixins import FastTenantTestCase
 
-from .factories import AuditPartnerFactory
+from .factories import (
+    AuditPartnerFactory,
+    AuditorStaffMemberFactory,
+    EngagementFactory,
+    PurchaseOrderFactory,
+    RiskBluePrintFactory,
+    RiskCategoryFactory,
+    RiskFactory,
+    SpotCheckFactory,
+    )
 from ..models import AuditorStaffMember, Auditor
 from firms.factories import UserFactory
 
@@ -21,3 +37,93 @@ class AuditorStaffMemberTestCase(FastTenantTestCase):
         self.assertIn(Auditor.name, staff_member.user.groups.values_list('name', flat=True))
 
         self.assertEqual(len(mail.outbox), 1)
+
+
+@skipIf(sys.version_info.major == 3, "This test can be deleted under Python 3")
+class TestStrUnicode(TestCase):
+    '''Ensure calling str() on model instances returns UTF8-encoded text and unicode() returns unicode.'''
+    def test_auditor_staff_member(self):
+        user = UserFactory.build(first_name='Bugs', last_name='Bunny')
+        instance = AuditorStaffMemberFactory.build(user=user)
+        self.assertEqual(str(instance), b'Bugs Bunny')
+        self.assertEqual(unicode(instance), 'Bugs Bunny')
+
+        user = UserFactory.build(first_name='Harald', last_name='H\xe5rdr\xe5da')
+        instance = AuditorStaffMemberFactory.build(user=user)
+        self.assertEqual(str(instance), b'Harald H\xc3\xa5rdr\xc3\xa5da')
+        self.assertEqual(unicode(instance), 'Harald H\xe5rdr\xe5da')
+
+    def test_purchase_order(self):
+        instance = PurchaseOrderFactory.build(order_number=b'two')
+        self.assertEqual(str(instance), b'two')
+        self.assertEqual(unicode(instance), 'two')
+
+        instance = PurchaseOrderFactory.build(order_number='tv\xe5')
+        self.assertEqual(str(instance), b'tv\xc3\xa5')
+        self.assertEqual(unicode(instance), 'tv\xe5')
+
+    def test_engagement(self):
+        purchase_order = PurchaseOrderFactory.build(order_number='two')
+        instance = EngagementFactory.build(agreement=purchase_order)
+        self.assertIn(b' two,', str(instance))
+        self.assertIn(' two,', unicode(instance))
+
+        purchase_order = PurchaseOrderFactory.build(order_number='tv\xe5')
+        instance = EngagementFactory.build(agreement=purchase_order)
+        self.assertIn(b' tv\xc3\xa5,', str(instance))
+        self.assertIn(' tv\xe5,', unicode(instance))
+
+    def test_rick_category(self):
+        instance = RiskCategoryFactory.build(header='two')
+        self.assertEqual(str(instance), b'RiskCategory two')
+        self.assertEqual(unicode(instance), 'RiskCategory two')
+
+        instance = RiskCategoryFactory.build(header='tv\xe5')
+        self.assertEqual(str(instance), b'RiskCategory tv\xc3\xa5')
+        self.assertEqual(unicode(instance), 'RiskCategory tv\xe5')
+
+    def test_risk_blueprint(self):
+        risk_category = RiskCategoryFactory.build(header='two')
+        instance = RiskBluePrintFactory.build(category=risk_category)
+        self.assertEqual(str(instance), b'RiskBluePrint at two')
+        self.assertEqual(unicode(instance), 'RiskBluePrint at two')
+
+        risk_category = RiskCategoryFactory.build(header='tv\xe5')
+        instance = RiskBluePrintFactory.build(category=risk_category)
+        self.assertEqual(str(instance), b'RiskBluePrint at tv\xc3\xa5')
+        self.assertEqual(unicode(instance), 'RiskBluePrint at tv\xe5')
+
+    def test_risk(self):
+        purchase_order = PurchaseOrderFactory.build(order_number='two')
+        engagement = EngagementFactory.build(agreement=purchase_order)
+        instance = RiskFactory.build(engagement=engagement)
+        self.assertIn(b' two,', str(instance))
+        self.assertIn(' two,', unicode(instance))
+
+        purchase_order = PurchaseOrderFactory.build(order_number='tv\xe5')
+        engagement = EngagementFactory.build(agreement=purchase_order)
+        instance = RiskFactory.build(engagement=engagement)
+        self.assertIn(b' tv\xc3\xa5,', str(instance))
+        self.assertIn(' tv\xe5,', unicode(instance))
+
+    def test_spot_check(self):
+        purchase_order = PurchaseOrderFactory.build(order_number='two')
+        instance = SpotCheckFactory.build(agreement=purchase_order)
+        self.assertIn(b' two,', str(instance))
+        self.assertIn(' two,', unicode(instance))
+
+        purchase_order = PurchaseOrderFactory.build(order_number='tv\xe5')
+        instance = SpotCheckFactory.build(agreement=purchase_order)
+        self.assertIn(b' tv\xc3\xa5,', str(instance))
+        self.assertIn(' tv\xe5,', unicode(instance))
+
+    def test_finding(self):
+        purchase_order = PurchaseOrderFactory.build(order_number='two')
+        instance = SpotCheckFactory.build(agreement=purchase_order)
+        self.assertIn(b' two,', str(instance))
+        self.assertIn(' two,', unicode(instance))
+
+        purchase_order = PurchaseOrderFactory.build(order_number='tv\xe5')
+        instance = SpotCheckFactory.build(agreement=purchase_order)
+        self.assertIn(b' tv\xc3\xa5,', str(instance))
+        self.assertIn(' tv\xe5,', unicode(instance))


### PR DESCRIPTION
Ensure all models in audit have Python 3-compatible `str()` methods using Django's `@python_2_unicode_compatible` decorator. Fixed a bug in `AuditorStaffMember`.

https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.encoding.python_2_unicode_compatible

Add non-ASCII tests for `str()` and `unicode()` methods for most audit models. 

In `EquiTrack/tests/test_all_models.py`, remove `audit` from the list of modules not tested for Python 3-compatibility since it's now compliant.