### PR TITLE
Fix transition to methods

### DIFF
--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -13,7 +13,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 from django.utils.functional import cached_property
 
-from django_fsm import FSMField, transition
+from django_fsm import FSMField, transition, RETURN_VALUE
 from smart_selects.db_fields import ChainedForeignKey
 from model_utils.models import (
     TimeFramedModel,
@@ -946,28 +946,28 @@ class Agreement(TimeStampedModel):
 
     @transition(field=status,
                 source=[DRAFT],
-                target=[SIGNED],
+                target=SIGNED,
                 conditions=[agreement_transition_to_signed_valid])
     def transition_to_signed(self):
         pass
 
     @transition(field=status,
                 source=[SIGNED],
-                target=[ENDED],
+                target=ENDED,
                 conditions=[agreement_transition_to_ended_valid])
     def transition_to_ended(self):
         pass
 
     @transition(field=status,
                 source=[SIGNED],
-                target=[SUSPENDED],
+                target=SUSPENDED,
                 conditions=[])
     def transition_to_suspended(self):
         pass
 
     @transition(field=status,
                 source=[SUSPENDED, SIGNED],
-                target=[DRAFT],
+                target=DRAFT,
                 conditions=[agreements_illegal_transition])
     def transition_to_cancelled(self):
         pass

--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -13,7 +13,7 @@ from django.utils.encoding import python_2_unicode_compatible
 from django.utils.translation import ugettext as _
 from django.utils.functional import cached_property
 
-from django_fsm import FSMField, transition, RETURN_VALUE
+from django_fsm import FSMField, transition
 from smart_selects.db_fields import ChainedForeignKey
 from model_utils.models import (
     TimeFramedModel,


### PR DESCRIPTION
The following methods;
- `transition_to_cancelled`
- `transition_to_terminated`

Will always result in `TransitionNotAllowed` due to the `agreements_illegal_transition` function always returning `False`.
`agreements_illegal_transition` is a condition for both these methods.

The question is whether these methods are in use, and I should tweak them a bit to allow transitions for the mentioned methods above?
If not in use, should I remove them?