### PR TITLE
Convert t2f models to Python 3-compatible str() methods

### DIFF
--- a/EquiTrack/EquiTrack/tests/test_all_models.py
+++ b/EquiTrack/EquiTrack/tests/test_all_models.py
@@ -27,7 +27,6 @@ EXCLUDED_PACKAGES = (
     # Python 3-compatible. As they're fixed one by one, they'll be removed from this list.
     'audit',
     'partners',
-    't2f',
     'users',
     'vision',
     'workplan',

--- a/EquiTrack/t2f/models.py
+++ b/EquiTrack/t2f/models.py
@@ -12,6 +12,7 @@ from django.contrib.auth.models import User
 from django.conf import settings
 from django.db import models, connection
 from django.template.loader import render_to_string
+from django.utils.encoding import python_2_unicode_compatible
 from django.utils.timezone import now as timezone_now
 from django.utils.translation import ugettext, ugettext_lazy
 from django_fsm import FSMField, transition
@@ -112,6 +113,7 @@ def mark_as_certified_or_completed_threshold_decorator(func):
     return wrapper
 
 
+@python_2_unicode_compatible
 class Travel(models.Model):
     PLANNED = 'planned'
     SUBMITTED = 'submitted'
@@ -179,7 +181,7 @@ class Travel(models.Model):
     approved_cost_traveler = models.DecimalField(max_digits=20, decimal_places=4, null=True, default=None)
     approved_cost_travel_agencies = models.DecimalField(max_digits=20, decimal_places=4, null=True, default=None)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.reference_number
 
     @property
@@ -453,6 +455,7 @@ class TravelActivity(models.Model):
         return self.travels.filter(traveler=self.primary_traveler).first().status
 
 
+@python_2_unicode_compatible
 class ItineraryItem(models.Model):
     travel = models.ForeignKey('Travel', related_name='itinerary')
     origin = models.CharField(max_length=255)
@@ -470,7 +473,7 @@ class ItineraryItem(models.Model):
         # https://groups.google.com/d/msg/django-users/NQO8OjCHhnA/r9qKklm5y0EJ
         order_with_respect_to = 'travel'
 
-    def __unicode__(self):
+    def __str__(self):
         return '{} {} - {}'.format(self.travel.reference_number, self.origin, self.destination)
 
 
@@ -656,6 +659,7 @@ class ActionPoint(models.Model):
             log.error('Was not able to send the email. Exception: %s', exc.message)
 
 
+@python_2_unicode_compatible
 class Invoice(models.Model):
     PENDING = 'pending'
     PROCESSING = 'processing'
@@ -701,7 +705,7 @@ class Invoice(models.Model):
     def message(self):
         return '\n'.join(self.messages)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.reference_number
 
 

--- a/EquiTrack/t2f/tests/test_models.py
+++ b/EquiTrack/t2f/tests/test_models.py
@@ -1,0 +1,49 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import sys
+from unittest import skipIf
+
+
+from EquiTrack.tests.mixins import FastTenantTestCase
+from t2f.tests.factories import (
+    InvoiceFactory,
+    ItineraryItemFactory,
+    TravelFactory,
+    )
+
+
+@skipIf(sys.version_info.major == 3, "This test can be deleted under Python 3")
+class TestStrUnicode(FastTenantTestCase):
+    '''Ensure calling str() on model instances returns UTF8-encoded text and unicode() returns unicode.'''
+    def test_travel(self):
+        instance = TravelFactory()
+        # This model's __str__() method contains only formatted integers, so it's not possible to challenge it
+        # with non-ASCII text. As long as str() and unicode() succeed, that's all the testing we can do.
+        str(instance)
+        unicode(instance)
+
+    def test_itinerary_item(self):
+        travel = TravelFactory()
+        instance = ItineraryItemFactory(origin=b'here', destination=b'there', travel=travel)
+        self.assertTrue(str(instance).endswith(b'here - there'))
+        self.assertTrue(unicode(instance).endswith(u'here - there'))
+
+        instance = ItineraryItemFactory(origin=b'here', destination=u'G\xf6teborg', travel=travel)
+        self.assertTrue(str(instance).endswith(b'here - G\xc3\xb6teborg'))
+        self.assertTrue(unicode(instance).endswith(u'here - G\xf6teborg'))
+
+        instance = ItineraryItemFactory(origin=u'Przemy\u015bl', destination=u'G\xf6teborg', travel=travel)
+        self.assertTrue(str(instance).endswith(b'Przemy\xc5\x9bl - G\xc3\xb6teborg'))
+        self.assertTrue(unicode(instance).endswith(u'Przemy\u015bl - G\xf6teborg'))
+
+    def test_invoice(self):
+        instance = InvoiceFactory(business_area=b'xyz')
+        self.assertTrue(str(instance).startswith(b'xyz/'))
+        self.assertTrue(unicode(instance).startswith(u'xyz/'))
+
+        instance = InvoiceFactory(business_area=u'G\xf6teborg')
+        self.assertTrue(str(instance).startswith(b'G\xc3\xb6teborg/'))
+        self.assertTrue(unicode(instance).startswith(u'G\xf6teborg/'))

--- a/EquiTrack/t2f/tests/test_models.py
+++ b/EquiTrack/t2f/tests/test_models.py
@@ -19,11 +19,13 @@ from t2f.tests.factories import (
 class TestStrUnicode(FastTenantTestCase):
     '''Ensure calling str() on model instances returns UTF8-encoded text and unicode() returns unicode.'''
     def test_travel(self):
-        instance = TravelFactory()
-        # This model's __str__() method contains only formatted integers, so it's not possible to challenge it
-        # with non-ASCII text. As long as str() and unicode() succeed, that's all the testing we can do.
-        str(instance)
-        unicode(instance)
+        instance = TravelFactory(reference_number=b'two')
+        self.assertEqual(str(instance), b'two')
+        self.assertEqual(unicode(instance), u'two')
+
+        instance = TravelFactory(reference_number=u'tv\xe5')
+        self.assertEqual(str(instance), b'tv\xc3\xa5')
+        self.assertEqual(unicode(instance), u'tv\xe5')
 
     def test_itinerary_item(self):
         travel = TravelFactory()


### PR DESCRIPTION
Convert all models in `t2f` to Python 3-compatible `__str()__` methods using Django's `@python_2_unicode_compatible decorator` while retaining compatibility with Python 2.

https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.encoding.python_2_unicode_compatible

Add non-ASCII tests for `str()` and `unicode()` methods for each model.

Only 3 models in `t2f` have `__str__()` methods, so this is a small change.