### PR TITLE
upgrade celery to latest 3.x version 

### DIFF
--- a/EquiTrack/requirements/base.txt
+++ b/EquiTrack/requirements/base.txt
@@ -44,7 +44,7 @@ djangorestframework-recursive==0.1.1
 # Other Python packages
 logutils==0.3.3
 psycopg2==2.6.2
-celery==3.1.23
+celery==3.1.25
 hiredis==0.2.0
 GDAL==1.10.0           # DO NOT USE GDAL <= 2.1.0
 carto==1.0.1


### PR DESCRIPTION
needed to migrate to celery version 4.x)