### PR TITLE
Make partners models str method python 2 and 3 compatible

### DIFF
--- a/EquiTrack/EquiTrack/tests/test_all_models.py
+++ b/EquiTrack/EquiTrack/tests/test_all_models.py
@@ -25,7 +25,6 @@ EXCLUDED_PACKAGES = (
 
     # These are the eTools packages that aren't yet using @python_2_unicode_compatible and therefore aren't yet
     # Python 3-compatible. As they're fixed one by one, they'll be removed from this list.
-    'partners',
     'users',
     'workplan',
     )

--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -143,6 +143,7 @@ def get_agreement_amd_file_path(instance, filename):
 # TODO: move this to a workspace app for common configuration options
 
 
+@python_2_unicode_compatible
 class WorkspaceFileType(models.Model):
     """
     Represents a file type
@@ -150,7 +151,7 @@ class WorkspaceFileType(models.Model):
 
     name = models.CharField(max_length=64, unique=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -198,6 +199,7 @@ def hact_default():
     }
 
 
+@python_2_unicode_compatible
 class PartnerOrganization(AdminURLMixin, models.Model):
     """
     Represents a partner organization
@@ -375,7 +377,7 @@ class PartnerOrganization(AdminURLMixin, models.Model):
         ordering = ['name']
         unique_together = ('name', 'vendor_number')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def latest_assessment(self, type):
@@ -598,6 +600,7 @@ class PartnerStaffMemberManager(models.Manager):
         return super(PartnerStaffMemberManager, self).get_queryset().select_related('partner')
 
 
+@python_2_unicode_compatible
 class PartnerStaffMember(models.Model):
     """
     Represents a staff member at the partner organization.
@@ -628,7 +631,7 @@ class PartnerStaffMember(models.Model):
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
 
-    def __unicode__(self):
+    def __str__(self):
         return'{} {} ({})'.format(
             self.first_name,
             self.last_name,
@@ -657,6 +660,7 @@ class PartnerStaffMember(models.Model):
         return super(PartnerStaffMember, self).save(**kwargs)
 
 
+@python_2_unicode_compatible
 class Assessment(models.Model):
     """
     Represents an assessment for a partner organization.
@@ -733,7 +737,7 @@ class Assessment(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return'{type}: {partner} {rating} {date}'.format(
             type=self.type,
             partner=self.partner.name,
@@ -779,6 +783,7 @@ def activity_to_active_side_effects(i, old_instance=None, user=None):
     pass
 
 
+@python_2_unicode_compatible
 class Agreement(TimeStampedModel):
     """
     Represents an agreement with the partner organization.
@@ -880,7 +885,7 @@ class Agreement(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return'{} for {} ({} - {})'.format(
             self.agreement_type,
             self.partner.name,
@@ -1012,6 +1017,7 @@ class Agreement(TimeStampedModel):
         return super(Agreement, self).save()
 
 
+@python_2_unicode_compatible
 class AgreementAmendment(TimeStampedModel):
     '''
     Represents an amendment to an agreement
@@ -1042,7 +1048,7 @@ class AgreementAmendment(TimeStampedModel):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return "{} {}".format(
             self.agreement.reference_number,
             self.number
@@ -1094,6 +1100,7 @@ def side_effect_two(i, old_instance=None, user=None):
     pass
 
 
+@python_2_unicode_compatible
 class Intervention(TimeStampedModel):
     """
     Represents a partner intervention.
@@ -1254,7 +1261,7 @@ class Intervention(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}'.format(
             self.number
         )
@@ -1506,6 +1513,7 @@ class Intervention(TimeStampedModel):
         super(Intervention, self).save()
 
 
+@python_2_unicode_compatible
 class InterventionAmendment(TimeStampedModel):
     """
     Represents an amendment for the partner intervention.
@@ -1572,7 +1580,7 @@ class InterventionAmendment(TimeStampedModel):
             self.intervention.save(amendment_number=self.amendment_number)
         return super(InterventionAmendment, self).save(**kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}:- {}'.format(
             self.amendment_number,
             self.signed_date
@@ -1600,6 +1608,7 @@ class InterventionPlannedVisits(models.Model):
         unique_together = ('intervention', 'year')
 
 
+@python_2_unicode_compatible
 class InterventionResultLink(models.Model):
     intervention = models.ForeignKey(Intervention, related_name='result_links')
     cp_output = models.ForeignKey(Result, related_name='intervention_links')
@@ -1607,7 +1616,7 @@ class InterventionResultLink(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return '{} {}'.format(
             self.intervention, self.cp_output
         )
@@ -1663,6 +1672,7 @@ class InterventionBudget(TimeStampedModel):
         )
 
 
+@python_2_unicode_compatible
 class FileType(models.Model):
     """
     Represents a file type
@@ -1688,10 +1698,11 @@ class FileType(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class InterventionAttachment(TimeStampedModel):
     """
     Represents a file for the partner intervention
@@ -1712,7 +1723,7 @@ class InterventionAttachment(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return self.attachment.name
 
 
@@ -1731,6 +1742,7 @@ class GovernmentInterventionManager(models.Manager):
 
 
 # TODO: check this for sanity
+@python_2_unicode_compatible
 class GovernmentIntervention(models.Model):
     """
     Represents a government intervention.
@@ -1758,7 +1770,7 @@ class GovernmentIntervention(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return 'Number: {}'.format(self.number) if self.number else \
             '{}: {}'.format(self.pk, self.reference_number)
 
@@ -1794,6 +1806,7 @@ def activity_default():
     return {}
 
 
+@python_2_unicode_compatible
 class GovernmentInterventionResult(models.Model):
     """
     Represents an result from government intervention.
@@ -1848,7 +1861,7 @@ class GovernmentInterventionResult(models.Model):
 
         super(GovernmentInterventionResult, self).save(**kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}, {}'.format(self.intervention.number, self.result)
 
 

--- a/EquiTrack/partners/tests/factories.py
+++ b/EquiTrack/partners/tests/factories.py
@@ -1,0 +1,81 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import factory
+
+from EquiTrack.factories import (
+    GovernmentInterventionFactory,
+    InterventionFactory,
+    PartnerFactory,
+    ResultFactory,
+    )
+from partners.models import (
+    Assessment,
+    FileType,
+    GovernmentInterventionResult,
+    InterventionAmendment,
+    InterventionAttachment,
+    InterventionResultLink,
+    WorkspaceFileType,
+    )
+
+
+class AssessmentFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = Assessment
+
+    type = Assessment.ASSESMENT_TYPES[0]
+    partner = factory.SubFactory(PartnerFactory)
+
+
+class FileTypeFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = FileType
+
+    name = FileType.PROGRESS_REPORT
+
+
+class GovernmentInterventionResultFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = GovernmentInterventionResult
+
+    intervention = factory.SubFactory(GovernmentInterventionFactory)
+    result = factory.SubFactory(ResultFactory)
+    year = '2017'
+
+
+class InterventionAmendmentFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = InterventionAmendment
+
+    intervention = factory.SubFactory(InterventionFactory)
+
+
+class InterventionAttachmentFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = InterventionAttachment
+
+    intervention = factory.SubFactory(InterventionFactory)
+    type = factory.SubFactory(FileTypeFactory)
+
+
+class InterventionResultLinkFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = InterventionResultLink
+
+    intervention = factory.SubFactory(InterventionFactory)
+    cp_output = factory.SubFactory(ResultFactory)
+
+
+class WorkspaceFileTypeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = WorkspaceFileType
+
+    name = factory.Sequence(lambda n: 'workspace file type {}'.format(n))


### PR DESCRIPTION
Convert all models in `partners ` to Python 3-compatible `__str()__` methods using Django's `@python_2_unicode_compatible decorator` while retaining compatibility with Python 2.

https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.encoding.python_2_unicode_compatible

Add non-ASCII tests for `str()` and `unicode()` methods for each model.

Add factories as necessary for tests.  New factories were added to the new file `partners/tests/factories.py`.