### PR TITLE
Make partners models Python 2/3 compatible

### DIFF
--- a/EquiTrack/EquiTrack/tests/test_all_models.py
+++ b/EquiTrack/EquiTrack/tests/test_all_models.py
@@ -22,7 +22,6 @@ EXCLUDED_PACKAGES = (
     # These are the eTools packages that aren't yet using @python_2_unicode_compatible and therefore aren't yet
     # Python 3-compatible. As they're fixed one by one, they'll be removed from this list.
     'audit',
-    'partners',
     't2f',
     'users',
     'vision',

--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -140,6 +140,7 @@ def _get_currency_name_or_default(budget):
 # TODO: move this to a workspace app for common configuration options
 
 
+@python_2_unicode_compatible
 class WorkspaceFileType(models.Model):
     """
     Represents a file type
@@ -147,7 +148,7 @@ class WorkspaceFileType(models.Model):
 
     name = models.CharField(max_length=64, unique=True)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
@@ -176,6 +177,7 @@ def hact_default():
     }
 
 
+@python_2_unicode_compatible
 class PartnerOrganization(AdminURLMixin, TimeStampedModel):
     """
     Represents a partner organization
@@ -411,7 +413,7 @@ class PartnerOrganization(AdminURLMixin, TimeStampedModel):
         ordering = ['name']
         unique_together = ('name', 'vendor_number')
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
     def latest_assessment(self, type):
@@ -634,6 +636,7 @@ class PartnerStaffMemberManager(models.Manager):
         return super(PartnerStaffMemberManager, self).get_queryset().select_related('partner')
 
 
+@python_2_unicode_compatible
 class PartnerStaffMember(TimeStampedModel):
     """
     Represents a staff member at the partner organization.
@@ -683,7 +686,7 @@ class PartnerStaffMember(TimeStampedModel):
         full_name = '%s %s' % (self.first_name, self.last_name)
         return full_name.strip()
 
-    def __unicode__(self):
+    def __str__(self):
         return'{} {} ({})'.format(
             self.first_name,
             self.last_name,
@@ -712,6 +715,7 @@ class PartnerStaffMember(TimeStampedModel):
         return super(PartnerStaffMember, self).save(**kwargs)
 
 
+@python_2_unicode_compatible
 class Assessment(TimeStampedModel):
     """
     Represents an assessment for a partner organization.
@@ -813,7 +817,7 @@ class Assessment(TimeStampedModel):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return'{type}: {partner} {rating} {date}'.format(
             type=self.type,
             partner=self.partner.name,
@@ -859,6 +863,7 @@ def activity_to_active_side_effects(i, old_instance=None, user=None):
     pass
 
 
+@python_2_unicode_compatible
 class Agreement(TimeStampedModel):
     """
     Represents an agreement with the partner organization.
@@ -987,7 +992,7 @@ class Agreement(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return'{} for {} ({} - {})'.format(
             self.agreement_type,
             self.partner.name,
@@ -1125,6 +1130,7 @@ class AgreementAmendmentManager(models.Manager):
         return super(AgreementAmendmentManager, self).get_queryset().select_related('agreement__partner')
 
 
+@python_2_unicode_compatible
 class AgreementAmendment(TimeStampedModel):
     '''
     Represents an amendment to an agreement
@@ -1166,7 +1172,7 @@ class AgreementAmendment(TimeStampedModel):
     view_objects = AgreementAmendmentManager()
     objects = models.Manager()
 
-    def __unicode__(self):
+    def __str__(self):
         return "{} {}".format(
             self.agreement.reference_number,
             self.number
@@ -1234,6 +1240,7 @@ def side_effect_two(i, old_instance=None, user=None):
     pass
 
 
+@python_2_unicode_compatible
 class Intervention(TimeStampedModel):
     """
     Represents a partner intervention.
@@ -1446,7 +1453,7 @@ class Intervention(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}'.format(
             self.number
         )
@@ -1731,6 +1738,7 @@ class Intervention(TimeStampedModel):
         super(Intervention, self).save()
 
 
+@python_2_unicode_compatible
 class InterventionAmendment(TimeStampedModel):
     """
     Represents an amendment for the partner intervention.
@@ -1803,7 +1811,7 @@ class InterventionAmendment(TimeStampedModel):
 
         return super(InterventionAmendment, self).save(**kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}:- {}'.format(
             self.amendment_number,
             self.signed_date
@@ -1831,6 +1839,7 @@ class InterventionPlannedVisits(TimeStampedModel):
         unique_together = ('intervention', 'year')
 
 
+@python_2_unicode_compatible
 class InterventionResultLink(TimeStampedModel):
     intervention = models.ForeignKey(Intervention, related_name='result_links')
     cp_output = models.ForeignKey(Result, related_name='intervention_links')
@@ -1838,7 +1847,7 @@ class InterventionResultLink(TimeStampedModel):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return '{} {}'.format(
             self.intervention, self.cp_output
         )
@@ -1894,6 +1903,7 @@ class InterventionBudget(TimeStampedModel):
         )
 
 
+@python_2_unicode_compatible
 class FileType(models.Model):
     """
     Represents a file type
@@ -1919,10 +1929,11 @@ class FileType(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class InterventionAttachment(TimeStampedModel):
     """
     Represents a file for the partner intervention
@@ -1943,7 +1954,7 @@ class InterventionAttachment(TimeStampedModel):
     class Meta:
         ordering = ['-created']
 
-    def __unicode__(self):
+    def __str__(self):
         return self.attachment.name
 
 
@@ -1986,6 +1997,7 @@ class GovernmentInterventionManager(models.Manager):
 
 
 # TODO: check this for sanity
+@python_2_unicode_compatible
 class GovernmentIntervention(models.Model):
     """
     Represents a government intervention.
@@ -2013,7 +2025,7 @@ class GovernmentIntervention(models.Model):
 
     tracker = FieldTracker()
 
-    def __unicode__(self):
+    def __str__(self):
         return 'Number: {}'.format(self.number) if self.number else \
             '{}: {}'.format(self.pk, self.reference_number)
 
@@ -2049,6 +2061,7 @@ def activity_default():
     return {}
 
 
+@python_2_unicode_compatible
 class GovernmentInterventionResult(models.Model):
     """
     Represents an result from government intervention.
@@ -2103,7 +2116,7 @@ class GovernmentInterventionResult(models.Model):
 
         super(GovernmentInterventionResult, self).save(**kwargs)
 
-    def __unicode__(self):
+    def __str__(self):
         return '{}, {}'.format(self.intervention.number, self.result)
 
 

--- a/EquiTrack/partners/models.py
+++ b/EquiTrack/partners/models.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 from __future__ import unicode_literals
 import datetime
+import decimal
 import json
 
 from django.conf import settings
@@ -1897,9 +1898,11 @@ class InterventionBudget(TimeStampedModel):
         super(InterventionBudget, self).save(**kwargs)
 
     def __str__(self):
+        # self.total is None if object hasn't been saved yet
+        total = self.total if self.total else decimal.Decimal('0.00')
         return '{}: {:.2f}'.format(
             self.intervention,
-            self.total
+            total
         )
 
 

--- a/EquiTrack/partners/tests/factories.py
+++ b/EquiTrack/partners/tests/factories.py
@@ -1,0 +1,32 @@
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import factory
+
+from EquiTrack.factories import (
+    GovernmentInterventionFactory,
+    ResultFactory,
+    )
+from partners.models import (
+    GovernmentInterventionResult,
+    WorkspaceFileType,
+    )
+
+
+class GovernmentInterventionResultFactory(factory.django.DjangoModelFactory):
+
+    class Meta:
+        model = GovernmentInterventionResult
+
+    intervention = factory.SubFactory(GovernmentInterventionFactory)
+    result = factory.SubFactory(ResultFactory)
+    year = '2017'
+
+
+class WorkspaceFileTypeFactory(factory.django.DjangoModelFactory):
+    class Meta:
+        model = WorkspaceFileType
+
+    name = factory.Sequence(lambda n: 'workspace file type {}'.format(n))

--- a/EquiTrack/partners/tests/test_models.py
+++ b/EquiTrack/partners/tests/test_models.py
@@ -787,9 +787,9 @@ class TestInterventionModel(TenantTestCase):
             submission_date=datetime.date(datetime.date.today().year, 1, 1),
         )
 
-    def test_unicode(self):
+    def test_str(self):
         number = self.intervention.number
-        self.assertEqual(unicode(self.intervention), number)
+        self.assertEqual(str(self.intervention), number)
 
     def test_permission_structure(self):
         permissions = models.Intervention.permission_structure()
@@ -1411,15 +1411,15 @@ class TestGetFilePaths(TenantTestCase):
 
 
 class TestWorkspaceFileType(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         w = models.WorkspaceFileType(name="Test")
-        self.assertEqual(unicode(w), u"Test")
+        self.assertEqual(str(w), "Test")
 
 
 class TestPartnerOrganization(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         p = models.PartnerOrganization(name="Test Partner Org")
-        self.assertEqual(unicode(p), "Test Partner Org")
+        self.assertEqual(str(p), "Test Partner Org")
 
     def test_save_exception(self):
         p = models.PartnerOrganization(name="Test", hact_values="wrong")
@@ -1447,14 +1447,14 @@ class TestPartnerOrganization(TenantTestCase):
 
 
 class TestPartnerStaffMember(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         partner = models.PartnerOrganization(name="Partner")
         staff = models.PartnerStaffMember(
             first_name="First",
             last_name="Last",
             partner=partner
         )
-        self.assertEqual(unicode(staff), "First Last (Partner)")
+        self.assertEqual(str(staff), "First Last (Partner)")
 
     def test_save_update_deactivate(self):
         partner = PartnerFactory()
@@ -1483,16 +1483,16 @@ class TestPartnerStaffMember(TenantTestCase):
 
 
 class TestAssessment(TenantTestCase):
-    def test_unicode_not_completed(self):
+    def test_str_not_completed(self):
         partner = models.PartnerOrganization(name="Partner")
         a = models.Assessment(
             partner=partner,
             type="Type",
             rating="Rating",
         )
-        self.assertEqual(unicode(a), "Type: Partner Rating NOT COMPLETED")
+        self.assertEqual(str(a), "Type: Partner Rating NOT COMPLETED")
 
-    def test_unicode_completed(self):
+    def test_str_completed(self):
         partner = models.PartnerOrganization(name="Partner")
         a = models.Assessment(
             partner=partner,
@@ -1500,7 +1500,7 @@ class TestAssessment(TenantTestCase):
             rating="Rating",
             completed_date=datetime.date(2001, 1, 1)
         )
-        self.assertEqual(unicode(a), "Type: Partner Rating 01-01-2001")
+        self.assertEqual(str(a), "Type: Partner Rating 01-01-2001")
 
     def test_save_update_micro_assessment(self):
         partner = PartnerFactory(
@@ -1538,15 +1538,15 @@ class TestAssessment(TenantTestCase):
 
 
 class TestAgreement(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         partner = models.PartnerOrganization(name="Partner")
         agreement = models.Agreement(
             partner=partner,
             agreement_type=models.Agreement.DRAFT,
         )
-        self.assertEqual(unicode(agreement), "draft for Partner ( - )")
+        self.assertEqual(str(agreement), "draft for Partner ( - )")
 
-    def test_unicode_dates(self):
+    def test_str_dates(self):
         partner = models.PartnerOrganization(name="Partner")
         agreement = models.Agreement(
             partner=partner,
@@ -1555,7 +1555,7 @@ class TestAgreement(TenantTestCase):
             end=datetime.date(2002, 1, 1),
         )
         self.assertEqual(
-            unicode(agreement),
+            str(agreement),
             "draft for Partner (01-01-2001 - 01-01-2002)"
         )
 
@@ -1609,26 +1609,26 @@ class TestAgreement(TenantTestCase):
 
 
 class TestAgreementAmendment(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         agreement = AgreementFactory()
         amendment = AgreementAmendmentFactory(
             agreement=agreement
         )
         self.assertEqual(
-            unicode(amendment),
+            str(amendment),
             "{} {}".format(agreement.reference_number, amendment.number)
         )
 
 
 class TestInterventionAmendment(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         ia = models.InterventionAmendment(
             amendment_number="123",
             signed_date=None
         )
-        self.assertEqual(unicode(ia), "123:- None")
+        self.assertEqual(str(ia), "123:- None")
         ia.signed_date = datetime.date(2001, 1, 1)
-        self.assertEqual(unicode(ia), "123:- 2001-01-01")
+        self.assertEqual(str(ia), "123:- 2001-01-01")
 
     def test_compute_reference_number_no_amendments(self):
         intervention = InterventionFactory()
@@ -1646,7 +1646,7 @@ class TestInterventionAmendment(TenantTestCase):
 
 
 class TestInterventionResultLink(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         intervention = InterventionFactory()
         result = ResultFactory(
             name="Name",
@@ -1659,7 +1659,7 @@ class TestInterventionResultLink(TenantTestCase):
         intervention_str = str(intervention)
         result_str = str(result)
         self.assertEqual(
-            unicode(link),
+            str(link),
             "{} {}".format(intervention_str, result_str)
         )
 
@@ -1678,15 +1678,15 @@ class TestInterventionBudget(TenantTestCase):
 
 
 class TestFileType(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         f = models.FileType(name="FileType")
-        self.assertEqual(unicode(f), "FileType")
+        self.assertEqual(str(f), "FileType")
 
 
 class TestInterventionAttachment(TenantTestCase):
-    def test_unicode(self):
+    def test_str(self):
         a = models.InterventionAttachment(attachment="test.pdf")
-        self.assertEqual(unicode(a), "test.pdf")
+        self.assertEqual(str(a), "test.pdf")
 
 
 class TestInterventionReportingPeriod(TenantTestCase):


### PR DESCRIPTION
Convert all models in `partners` to Python 3-compatible `__str()__` methods using Django's `@python_2_unicode_compatible decorator` while retaining compatibility with Python 2.

https://docs.djangoproject.com/en/1.11/ref/utils/#django.utils.encoding.python_2_unicode_compatible

 - Add non-ASCII tests for `str()` and `unicode()` methods for each model. 
 - Add factories as necessary for tests to new file `partners/tests/factories.py` (4ef366a5723e3b6c82718f85adb4990da663c0df)
 - Fix a small bug in `InterventionBudget` where `str()` would fail if called on an instance that hadn't yet been saved. (f18c9acf2cc38cdf9680fca3b5ce63c27827cba9)
 - In `test_models.py`, changed `test_unicode()` methods to `test_str()` (36d2485f2cae56d31bd59886b94fbb2933b337d3)