### PR TITLE
Fix spurious test failure in audit

### DIFF
--- a/EquiTrack/audit/tests/test_views.py
+++ b/EquiTrack/audit/tests/test_views.py
@@ -250,8 +250,8 @@ class TestEngagementsListViewSet(EngagementTransitionsTestCaseMixin, APITenantTe
         self.assertIn('results', response.data)
         self.assertIsInstance(response.data['results'], list)
         self.assertListEqual(
-            map(lambda x: x['id'], response.data['results']),
-            map(lambda x: x.id, engagements)
+            sorted(map(lambda x: x['id'], response.data['results'])),
+            sorted(map(lambda x: x.id, engagements))
         )
 
     def test_focal_point_list(self):


### PR DESCRIPTION
Sort lists of ids before comparing to ensure database randomness doesn't cause spurious test failure.

This test has contained this flaw for 6 months but it just now started failing on my machine. Curious!