### PR TITLE
Upgrade djangosaml2

### DIFF
--- a/EquiTrack/EquiTrack/settings/base.py
+++ b/EquiTrack/EquiTrack/settings/base.py
@@ -413,7 +413,8 @@ SAML_ATTRIBUTE_MAPPING = {
     'givenName': ('first_name',),
     'surname': ('last_name',),
 }
-SAML_DJANGO_USER_MAIN_ATTRIBUTE = 'email'
+SAML_DJANGO_USER_MAIN_ATTRIBUTE = 'username'
+SAML_USE_NAME_ID_AS_USERNAME = True
 SAML_CREATE_UNKNOWN_USER = True
 SAML_CONFIG = {
     # full path to the xmlsec1 binary programm
@@ -467,6 +468,10 @@ SAML_CONFIG = {
     # certificate
     'key_file': join(DJANGO_ROOT, 'saml/certs/saml.key'),  # private part
     'cert_file': join(DJANGO_ROOT, 'saml/certs/sp.crt'),  # public part
+    'encryption_keypairs': [{
+        'key_file': join(DJANGO_ROOT, 'saml/certs/saml.key'),
+        'cert_file': join(DJANGO_ROOT, 'saml/certs/sp.crt'),
+    }],
 
     # own metadata settings
     'contact_person': [

--- a/EquiTrack/EquiTrack/settings/base.py
+++ b/EquiTrack/EquiTrack/settings/base.py
@@ -413,8 +413,7 @@ SAML_ATTRIBUTE_MAPPING = {
     'givenName': ('first_name',),
     'surname': ('last_name',),
 }
-SAML_DJANGO_USER_MAIN_ATTRIBUTE = 'username'
-SAML_USE_NAME_ID_AS_USERNAME = True
+SAML_DJANGO_USER_MAIN_ATTRIBUTE = 'email'
 SAML_CREATE_UNKNOWN_USER = True
 SAML_CONFIG = {
     # full path to the xmlsec1 binary programm

--- a/EquiTrack/requirements/base.txt
+++ b/EquiTrack/requirements/base.txt
@@ -75,5 +75,5 @@ flake8==3.3.0
 mock==2.0.0
 
 # Git python packages
-git+https://github.com/unicef/djangosaml2.git@v0.16.11.1#egg=djangosaml2
+git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
 git+https://github.com/robertavram/django-storages.git@1.6.5.1#egg=django-storages

--- a/EquiTrack/requirements/base.txt
+++ b/EquiTrack/requirements/base.txt
@@ -75,5 +75,5 @@ flake8==3.3.0
 mock==2.0.0
 
 # Git python packages
-git+https://github.com/robertavram/djangosaml2.git@0.13.3#egg=djangosaml2
+git+https://github.com/unicef/djangosaml2.git@v0.16.11.1#egg=djangosaml2
 git+https://github.com/robertavram/django-storages.git@1.6.5.1#egg=django-storages


### PR DESCRIPTION
Being able to upgrade Django 1.10 requires us to either replace djangosaml2 or update it.

If we want to update it, I [forked](https://github.com/unicef/djangosaml2) the maintained version of djangosaml2 which is Django 1.10 compatible and applied the tweaks that had been made to our current version of djangosaml2.

This pull request is against develop and replaces https://github.com/unicef/etools/pull/1117