### PR TITLE
Retry vision sync tasks on failure

### DIFF
--- a/EquiTrack/vision/tasks.py
+++ b/EquiTrack/vision/tasks.py
@@ -1,5 +1,4 @@
-import datetime
-import time
+from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.db import connection
 from django.utils import timezone
@@ -7,15 +6,11 @@ from django.utils import timezone
 from celery.utils.log import get_task_logger
 
 from EquiTrack.celery import app, send_to_slack
-from partners.models import PartnerOrganization
 from users.models import Country
 from vision.adapters.funding import FundCommitmentSynchronizer, FundReservationsSynchronizer
 from vision.adapters.partner import PartnerSynchronizer
 from vision.adapters.programme import ProgrammeSynchronizer, RAMSynchronizer
-from vision.adapters.publics_adapter import CostAssignmentSynch
-from vision.adapters.purchase_order import POSynchronizer
 from vision.exceptions import VisionException
-from vision.models import VisionSyncLog
 
 PUBLIC_SYNC_HANDLERS = []
 
@@ -32,57 +27,14 @@ SYNC_HANDLERS = [
 logger = get_task_logger(__name__)
 
 
-@app.task
-def fake_task_delay():
-    country = Country.objects.get(name="UAT")
-    log = VisionSyncLog(
-        country=country,
-        handler_name="Fake Task Delay 300"
-    )
-    log.save()
-    time.sleep(300)
-    log.successful = True
-    log.save()
-
-
-@app.task
-def fake_task_no_delay():
-    country = Country.objects.get(name="UAT")
-    log = VisionSyncLog(
-        country=country,
-        handler_name="Fake Task NoDelay 2"
-    )
-    time.sleep(2)
-    log.successful = True
-    log.save()
-
-
-@app.task
-def cost_assignment_sync(country_name=None):
-    processed = []
-    countries = Country.objects.filter(vision_sync_enabled=True)
-    if country_name is not None:
-        countries = countries.filter(name=country_name)
-
-    for country in countries:
-        connection.set_tenant(country)
-
-        try:
-            logger.info(u'Starting vision sync handler {} for country {}'.format(
-                CostAssignmentSynch.__name__, country.name
-            ))
-            CostAssignmentSynch(country).sync()
-            logger.info(u"{} sync successfully".format(CostAssignmentSynch.__name__))
-
-        except VisionException as e:
-            logger.error(u"{} sync failed, Reason: {}".format(
-                CostAssignmentSynch.__name__, e.message
-            ))
-        processed.append(country)
-
-
-@app.task
 def vision_sync_task(country_name=None, synchronizers=SYNC_HANDLERS):
+    """
+    Do the vision sync for all countries that have vision_sync_enabled=True,
+    or just the named country.  Defaults to SYNC_HANDLERS but a
+    different iterable of handlers can be passed in.
+    """
+    # Only invoked from management command and tests, not scheduled, as far as I can see,
+    # so it's not really a task as far as Celery is concerned.
 
     global_synchronizers = [handler for handler in synchronizers if handler.GLOBAL_CALL]
     tenant_synchronizers = [handler for handler in synchronizers if not handler.GLOBAL_CALL]
@@ -112,8 +64,12 @@ def vision_sync_task(country_name=None, synchronizers=SYNC_HANDLERS):
     logger.info(text)
 
 
-@app.task
-def sync_handler(country_name, handler):
+@app.task(bind=True)
+def sync_handler(self, country_name, handler):
+    """
+    Run .sync() on one handler for one country.
+    """
+    # Scheduled from vision_sync_task() (above).
     logger.info(u'Starting vision sync handler {} for country {}'.format(handler.__name__, country_name))
     try:
         country = Country.objects.get(name=country_name)
@@ -121,6 +77,7 @@ def sync_handler(country_name, handler):
         logger.error(u"{} sync failed, Could not find a Country with this name: {}".format(
             handler.__name__, country_name
         ))
+        # No point in retrying if there's no such country
     else:
         try:
             handler(country).sync()
@@ -130,93 +87,10 @@ def sync_handler(country_name, handler):
             logger.error(u"{} sync failed, Reason: {}, Country: {}".format(
                 handler.__name__, e.message, country_name
             ))
-
-
-@app.task
-def sync(country_name=None, synchronizers=None):
-    synchronizers = synchronizers or SYNC_HANDLERS
-    processed = []
-    countries = Country.objects.filter(vision_sync_enabled=True)
-    if country_name is not None:
-        countries = countries.filter(name=country_name)
-
-    global_handlers = [handler for handler in synchronizers if handler.GLOBAL_CALL]
-    tenant_handlers = [handler for handler in synchronizers if not handler.GLOBAL_CALL]
-
-    public_tenant = Country.objects.get(schema_name='public')
-    for handler in global_handlers:
-        try:
-            logger.info(u'Starting vision sync handler {} for country {}'.format(
-                handler.__name__, public_tenant.name
-            ))
-            handler(public_tenant).sync()
-            logger.info(u"{} sync successfully".format(handler.__name__))
-
-        except VisionException as e:
-            logger.error(u"{} sync failed, Reason: {}".format(
-                handler.__name__, e.message
-            ))
-
-    for country in countries:
-        connection.set_tenant(country)
-        for handler in tenant_handlers:
+            # This might be worth retrying.
             try:
-                logger.info(u'Starting vision sync handler {} for country {}'.format(
-                    handler.__name__, country.name
-                ))
-                handler(country).sync()
-                logger.info(u"{} sync successfully".format(handler.__name__))
-
-            except VisionException as e:
-                logger.error(u"{} sync failed, Reason: {}".format(
-                    handler.__name__, e.message
-                ))
-        country.vision_last_synced = datetime.datetime.now()
-        country.save()
-        processed.append(country)
-
-    text = u'Processed the following countries during sync: {}'.format(
-        ',\n '.join([country.name for country in processed])
-    )
-    send_to_slack(text)
-    logger.info(text)
-
-
-@app.task
-def update_all_partners(country_name=None):
-    logger.info(u'Starting update HACT values for partners')
-    countries = Country.objects.filter(vision_sync_enabled=True)
-    if country_name is not None:
-        countries = countries.filter(name=country_name)
-    for country in countries:
-        connection.set_tenant(country)
-        logger.info(u'Updating '.format(country.name))
-        partners = PartnerOrganization.objects.all()
-        for partner in partners:
-            try:
-                PartnerOrganization.planned_visits(partner)
-                PartnerOrganization.programmatic_visits(partner)
-                PartnerOrganization.spot_checks(partner)
-
-            except Exception:
-                logger.exception(u'Exception {} {}'.format(partner.name, partner.hact_values))
-
-
-@app.task
-def update_purchase_orders(country_name=None):
-    logger.info(u'Starting update values for purchase order')
-    countries = Country.objects.filter(vision_sync_enabled=True)
-    if country_name is not None:
-        countries = countries.filter(name=country_name)
-    for country in countries:
-        connection.set_tenant(country)
-        try:
-            logger.info(u'Starting purchase order update for country {}'.format(
-                country.name
-            ))
-            POSynchronizer(country).sync()
-            logger.info(u"Update finished successfully for {}".format(country.name))
-        except VisionException as e:
-                logger.error(u"{} sync failed, Reason: {}".format(
-                    POSynchronizer.__name__, e.message
-                ))
+                raise self.retry(exc=e)
+            except VisionException:
+                # We must have exceeded retries and Celery raised the original exception again.
+                # We've already logged it.
+                pass

--- a/EquiTrack/vision/tests/test_tasks.py
+++ b/EquiTrack/vision/tests/test_tasks.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import datetime
 from unittest import TestCase
 
+from django.test.utils import override_settings
 from django.utils import timezone
 
 import mock
@@ -148,6 +149,7 @@ class TestVisionSyncTask(TestCase):
         self.assertEqual(mock_logger.call_args[0], (expected_msg, ))
         self.assertEqual(mock_logger.call_args[1], {})
 
+    @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True)
     def test_sync_no_args_success_case(self, mock_logger, mock_django_db_connection, mock_handler, mock_send_to_slack,
                                        CountryMock):
         """Exercise vision.tasks.vision_sync_task() called without passing any argument"""
@@ -165,6 +167,7 @@ class TestVisionSyncTask(TestCase):
         self._assertSlackNotified(mock_send_to_slack)
         self._assertLoggerMessages(mock_logger)
 
+    @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True)
     def test_sync_country_filter_args(self, mock_logger, mock_django_db_connection, mock_handler, mock_send_to_slack,
                                       CountryMock):
         """Exercise vision.tasks.vision_sync_task() called with passing as argument a specific country"""
@@ -182,6 +185,7 @@ class TestVisionSyncTask(TestCase):
         self._assertSlackNotified(mock_send_to_slack, selected_countries)
         self._assertLoggerMessages(mock_logger, selected_countries)
 
+    @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True)
     def test_sync_synchronizer_filter_args(self, mock_logger, mock_django_db_connection, mock_handler,
                                            mock_send_to_slack, CountryMock):
         """Exercise vision.tasks.vision_sync_task() called with passing as argument a specific synchronizer"""
@@ -199,6 +203,7 @@ class TestVisionSyncTask(TestCase):
         self._assertSlackNotified(mock_send_to_slack, None, selected_synchronizers)
         self._assertLoggerMessages(mock_logger, None, selected_synchronizers)
 
+    @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True)
     def test_sync_country_and_synchronizer_filter_args(self, mock_logger, mock_django_db_connection, mock_handler,
                                                        mock_send_to_slack, CountryMock):
         """Exercise vision.tasks.vision_sync_task() called with passing a specific country and a synchronizer"""
@@ -228,11 +233,12 @@ class TestSyncHandlerTask(TestCase):
     @mock.patch('vision.tasks.logger.info')
     @mock.patch('vision.tasks.Country')
     @mock.patch('vision.tasks.ProgrammeSynchronizer.sync')
+    @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True)
     def test_sync_success(self, Handler, Country, mock_logger_info):
         """Exercise vision.tasks.sync_handler() success scenario, one matching country."""
         Country.objects.get = mock.Mock(return_value=self.country)
 
-        vision.tasks.sync_handler(self.country.name, ProgrammeSynchronizer)
+        vision.tasks.sync_handler.delay(self.country.name, ProgrammeSynchronizer)
         self.assertEqual(mock_logger_info.call_count, 2)
         expected_msg = '{} sync successfully for {}'.format(
             'ProgrammeSynchronizer', 'Country My'
@@ -244,19 +250,21 @@ class TestSyncHandlerTask(TestCase):
     @mock.patch('vision.tasks.logger.error')
     @mock.patch('vision.tasks.Country')
     @mock.patch('vision.tasks.ProgrammeSynchronizer.sync', side_effect=VisionException('banana'))
+    @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=False)
     def test_sync_vision_error(self, Handler, Country, mock_logger_error, mock_logger_info):
         """Exercise vision.tasks.sync_handler() which receive an exception from Vision."""
         Country.objects.get = mock.Mock(return_value=self.country)
 
-        vision.tasks.sync_handler(self.country.name, ProgrammeSynchronizer)
-        self.assertEqual(mock_logger_info.call_count, 1)
+        vision.tasks.sync_handler.delay(self.country.name, ProgrammeSynchronizer)
+        # Check that it got retried 3 times
+        self.assertEqual(mock_logger_info.call_count, 4)
+        self.assertEqual(mock_logger_error.call_count, 4)
         expected_msg = 'Starting vision sync handler {} for country {}'.format(
             'ProgrammeSynchronizer', 'Country My'
         )
         self.assertEqual(mock_logger_info.call_args[0], (expected_msg,))
         self.assertEqual(mock_logger_info.call_args[1], {})
 
-        self.assertEqual(mock_logger_error.call_count, 1)
         expected_msg = '{} sync failed, Reason: {}, Country: {}'.format(
             'ProgrammeSynchronizer', 'banana', 'Country My'
         )
@@ -264,9 +272,10 @@ class TestSyncHandlerTask(TestCase):
         self.assertEqual(mock_logger_error.call_args[1], {})
 
     @mock.patch('vision.tasks.logger.error')
+    @override_settings(CELERY_ALWAYS_EAGER=True, CELERY_EAGER_PROPAGATES_EXCEPTIONS=True)
     def test_sync_country_does_not_exist(self, mock_logger):
         """Exercise vision.tasks.sync_handler() called with a country name that doesn't match a country."""
-        vision.tasks.sync_handler('random', ProgrammeSynchronizer)
+        vision.tasks.sync_handler.delay('random', ProgrammeSynchronizer)
         self.assertEqual(mock_logger.call_count, 1)
         expected_msg = '{} sync failed, Could not find a Country with this name: {}'.format(
             'ProgrammeSynchronizer', 'random'


### PR DESCRIPTION
* Use Celery's retry feature to retry vision sync tasks that fail, at
  least a few times.

* Remove some unused code from vision/tasks.py.

For https://github.com/unicef/etools-issues/issues/1115