### PR TITLE
PRP Refactoring validation fixes

### DIFF
--- a/EquiTrack/partners/serializers/interventions_v2.py
+++ b/EquiTrack/partners/serializers/interventions_v2.py
@@ -96,9 +96,9 @@ class InterventionListSerializer(serializers.ModelSerializer):
 
     section_names = serializers.SerializerMethodField()
     flagged_sections = serializers.SerializerMethodField()
-    locations = serializers.SerializerMethodField()
-    location_names = serializers.SerializerMethodField()
-    cluster_names = serializers.SerializerMethodField()
+    # locations = serializers.SerializerMethodField()
+    # location_names = serializers.SerializerMethodField()
+    # cluster_names = serializers.SerializerMethodField()
     cp_outputs = serializers.SerializerMethodField()
     offices_names = serializers.SerializerMethodField()
     frs_earliest_start_date = serializers.DateField(source='frs__start_date__min', read_only=True)
@@ -135,22 +135,22 @@ class InterventionListSerializer(serializers.ModelSerializer):
         return [rl.cp_output.id for rl in obj.result_links.all()]
 
     def get_section_names(self, obj):
-        return [l.name for l in obj.flagged_sections]
+        return [l.name for l in obj.sections.all()]
 
     def get_flagged_sections(self, obj):
-        return [l.pk for l in obj.flagged_sections]
+        return [l.pk for l in obj.sections.all()]
 
-    def get_locations(self, obj):
-        return [l.pk for l in obj.intervention_locations]
+    # def get_locations(self, obj):
+    #     return [l.pk for l in obj.flat_locations.all()]
 
-    def get_location_names(self, obj):
-        return [
-            '{} [{} - {}]'.format(l.name, l.gateway.name, l.p_code)
-            for l in obj.intervention_locations
-        ]
+    # def get_location_names(self, obj):
+    #     return [
+    #         '{} [{} - {}]'.format(l.name, l.gateway.name, l.p_code)
+    #         for l in obj.flat_locations.all()
+    #     ]
 
-    def get_cluster_names(self, obj):
-        return [c for c in obj.intervention_clusters]
+    # def get_cluster_names(self, obj):
+    #     return [c for c in obj.intervention_clusters]
 
     class Meta:
         model = Intervention
@@ -181,9 +181,6 @@ class InterventionListSerializer(serializers.ModelSerializer):
             'total_unicef_budget',
             'total_budget',
             'metadata',
-            'locations',
-            'location_names',
-            'cluster_names',
             'flagged_sections'
         )
 

--- a/EquiTrack/partners/tests/test_api_interventions.py
+++ b/EquiTrack/partners/tests/test_api_interventions.py
@@ -1013,9 +1013,14 @@ class TestAPInterventionIndicatorsCreateView(APITenantTestCase):
                           kwargs={'lower_result_pk': cls.lower_result.id})
 
         location = LocationFactory()
+        section = SectorFactory()
+
+        cls.result_link.intervention.flat_locations.add(location)
+        cls.result_link.intervention.sections.add(section)
 
         cls.data = {'assumptions': 'lorem ipsum',
                     'locations': [location.id],
+                    'section': section.id,
                     # indicator (blueprint) is required because the AppliedIndicator model has a unique_together
                     # constraint of (indicator, lower_result).
                     'indicator': {'title': 'my indicator blueprint'},

--- a/EquiTrack/partners/tests/test_api_interventions.py
+++ b/EquiTrack/partners/tests/test_api_interventions.py
@@ -447,7 +447,7 @@ class TestInterventionsAPI(APITenantTestCase):
         self.ts = TenantSwitchFactory(name="prp_mode_off", countries=[connection.tenant])
         self.assertTrue(tenant_switch_is_active(self.ts.name))
 
-        EXPECTED_QUERIES = 11
+        EXPECTED_QUERIES = 10
         with self.assertNumQueries(EXPECTED_QUERIES):
             status_code, response = self.run_request_list_ep(user=self.unicef_staff, method='get')
 

--- a/EquiTrack/partners/views/interventions_v2.py
+++ b/EquiTrack/partners/views/interventions_v2.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import copy
 
-from django.db import transaction
+from django.db import transaction, connection
 from django.db.models import Q, Max, Min, Sum
 
 from rest_framework import status
@@ -81,19 +81,11 @@ class InterventionListBaseView(ValidatorViewMixin, ListCreateAPIView):
             'planned_budget',
             'offices',
             'sections',
+            # TODO: Figure out a way in which to add locations that is more performant
+            # 'flat_locations',
             'result_links__cp_output',
-            'result_links__ll_results__applied_indicators__indicator',
-            'result_links__ll_results__applied_indicators__locations',
-            'result_links__ll_results__applied_indicators__locations__gateway',
             'unicef_focal_points',
         )
-
-        if tenant_switch_is_active("prp_mode_off"):
-            qs = qs.prefetch_related(
-                # only prefetch flat_locations when needed, as this has an
-                # impact on performance. Only needed when prp not enabled
-                'flat_locations',
-            )
 
         qs = qs.annotate(
             Max("frs__end_date"),

--- a/EquiTrack/partners/views/interventions_v2.py
+++ b/EquiTrack/partners/views/interventions_v2.py
@@ -734,5 +734,8 @@ class InterventionIndicatorsUpdateView(RetrieveUpdateDestroyAPIView):
     queryset = AppliedIndicator.objects.all()
 
     def delete(self, request, *args, **kwargs):
-        # make sure there are no indicators added to this LLO
-        raise ValidationError(u'Deleting an indicator is temporarily disabled..')
+        ai = self.get_object()
+        intervention = ai.lower_result.result_link.intervention
+        if not intervention.status == Intervention.DRAFT:
+            raise ValidationError(u'Deleting an indicator is only possible in status Draft.')
+        return super(InterventionIndicatorsUpdateView, self).delete(request, *args, **kwargs)

--- a/EquiTrack/partners/views/interventions_v2.py
+++ b/EquiTrack/partners/views/interventions_v2.py
@@ -3,7 +3,7 @@ import functools
 import logging
 import copy
 
-from django.db import transaction, connection
+from django.db import transaction
 from django.db.models import Q, Max, Min, Sum
 
 from rest_framework import status

--- a/EquiTrack/reports/serializers/v2.py
+++ b/EquiTrack/reports/serializers/v2.py
@@ -134,6 +134,19 @@ class AppliedIndicatorSerializer(serializers.ModelSerializer):
     def validate(self, attrs):
         lower_result = attrs.get('lower_result')
         blueprint_data = attrs.get('indicator')
+
+        # make sure locations are in the intervention
+        locations = set(l.id for l in attrs.get('locations', []))
+        if not locations.issubset(l.id for l in lower_result.result_link.intervention.flat_locations.all()):
+            raise ValidationError(_('This indicator can only have locations that were '
+                                    'previously saved on the intervention'))
+
+        # make sure section are in the intervention
+        section = attrs.get('section', [])
+        if section.id not in [s.id for s in lower_result.result_link.intervention.sections.all()]:
+            raise ValidationError(_('This indicator can only have a section that was '
+                                    'previously saved on the intervention'))
+
         if self.partial:
             if not isinstance(blueprint_data, IndicatorBlueprint):
                 raise ValidationError(

--- a/EquiTrack/reports/serializers/v2.py
+++ b/EquiTrack/reports/serializers/v2.py
@@ -1,4 +1,6 @@
 from django.db import transaction
+from django.utils.translation import ugettext as _
+
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 
@@ -142,7 +144,9 @@ class AppliedIndicatorSerializer(serializers.ModelSerializer):
                                     'previously saved on the intervention'))
 
         # make sure section are in the intervention
-        section = attrs.get('section', [])
+        section = attrs.get('section', None)
+        if section is None:
+            raise ValidationError(_('Section is required'))
         if section.id not in [s.id for s in lower_result.result_link.intervention.sections.all()]:
             raise ValidationError(_('This indicator can only have a section that was '
                                     'previously saved on the intervention'))


### PR DESCRIPTION
Locations and sections now need to be selected on the intervention to
be able to be added on an indicators.
Locations and sections cannot be removed from an intervention if they
are present on any indicator.
Indicators can now be deleted while in status draft