### PR TITLE
 Allow termination of same CP duplicate agreements older than 2015 july

### DIFF
--- a/EquiTrack/partners/validation/agreements.py
+++ b/EquiTrack/partners/validation/agreements.py
@@ -119,6 +119,7 @@ def ssfa_static(agreement):
 
 def one_pca_per_cp_per_partner(agreement):
     if agreement.agreement_type == agreement.PCA:
+        #Allow the termination of duplicated agreements started before 2015 July
         if agreement.status == agreement.TERMINATED and agreement.start <= date(2015, 7, 1):
             return True
 

--- a/EquiTrack/partners/validation/agreements.py
+++ b/EquiTrack/partners/validation/agreements.py
@@ -119,6 +119,9 @@ def ssfa_static(agreement):
 
 def one_pca_per_cp_per_partner(agreement):
     if agreement.agreement_type == agreement.PCA:
+        if agreement.status == agreement.TERMINATED and agreement.start <= date(2015, 7, 1):
+            return True
+
         # see if there are any PCAs in the CP other than this for this partner and started after july 2015
         if agreement.__class__.objects.filter(partner=agreement.partner,
                                               agreement_type=agreement.PCA,


### PR DESCRIPTION
Connects to https://app.clubhouse.io/unicefetools/story/4428/unable-to-terminate-the-pca-amongst-two-pcas-whose-start-date-is-before-july-2015-alm-508

I'm not 100% sure this is the right solution. The agreement validator wants to prevent creating duplicate PCA agreements per CP, but allows to create unlimited nr. of agreements if all of them are before 2015 July.