### PR TITLE
RAMSynchronizer: skip record criteria

### DIFF
--- a/EquiTrack/vision/adapters/programme.py
+++ b/EquiTrack/vision/adapters/programme.py
@@ -337,10 +337,18 @@ class RAMSynchronizer(VisionDataSynchronizer):
         return False
 
     def _save_records(self, records):
-
         processed = self.process_indicators(records)
-
         return processed
+
+    def _filter_records(self, records):
+        def is_valid_record(record):
+            for key in self.REQUIRED_KEYS:
+                if key not in record:
+                    return False
+            if record['INDICATOR_DESCRIPTION'] in ['', None] or record["INDICATOR_CODE"] in ['undefined', '', None]:
+                return False
+            return True
+        return filter(is_valid_record, records)
 
     def _clean_records(self, records):
         records = self._filter_records(records)


### PR DESCRIPTION
with 'undefined' INDICATOR_CODE and record with empty INDICATOR_DESCRIPTION