### PR TITLE
Fix dirty test

### DIFF
--- a/EquiTrack/EquiTrack/tests/test_all_models.py
+++ b/EquiTrack/EquiTrack/tests/test_all_models.py
@@ -5,13 +5,15 @@ from __future__ import unicode_literals
 
 import inspect
 import sys
-from unittest import skipIf, TestCase
+from unittest import skipIf
 
 from django.apps import apps
+from django.test import SimpleTestCase
 
 # EXCLUDED_PACKAGES are the packages we want to exclude from testing for Python-3 compatible __str__() implementations.
 # If a 3rd party app model fails in TestStrMethods, feel free to add the package to this list. We aren't interested in
 # testing 3rd party packages. If an eTools model fails in TestStrMethods, it needs to be fixed.
+
 EXCLUDED_PACKAGES = (
     'allauth',
     'corsheaders',
@@ -27,7 +29,7 @@ EXCLUDED_PACKAGES = (
 
 
 @skipIf(sys.version_info.major == 3, "This test can be deleted under Python 3")
-class TestStrMethods(TestCase):
+class TestStrMethods(SimpleTestCase):
     '''Ensure all models in this project that implement __str__() or __unicode__() use the Django decorator
     python_2_unicode_compatible. Models from non-eTools packages are excluded; we're not interested in
     testing them.

--- a/EquiTrack/EquiTrack/tests/test_parsers.py
+++ b/EquiTrack/EquiTrack/tests/test_parsers.py
@@ -3,12 +3,12 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 
-from unittest import TestCase
+from django.test import SimpleTestCase
 
 from EquiTrack import parsers
 
 
-class TestIntOrString(TestCase):
+class TestIntOrString(SimpleTestCase):
     def test_int(self):
         self.assertEqual(parsers._int_or_str(1), 1)
 
@@ -19,7 +19,7 @@ class TestIntOrString(TestCase):
         self.assertEqual(parsers._int_or_str("one"), "one")
 
 
-class TestNaturalKeys(TestCase):
+class TestNaturalKeys(SimpleTestCase):
     def test_int(self):
         self.assertEqual(parsers._natural_keys('123'), ["", 123, ""])
 
@@ -34,7 +34,7 @@ class TestNaturalKeys(TestCase):
         )
 
 
-class TestCreateListsFromDictKeys(TestCase):
+class TestCreateListsFromDictKeys(SimpleTestCase):
     def test_empty_dict(self):
         self.assertEqual(parsers._create_lists_from_dict_keys({}), [])
 
@@ -72,7 +72,7 @@ class TestCreateListsFromDictKeys(TestCase):
         )
 
 
-class TestCreateKey(TestCase):
+class TestCreateKey(SimpleTestCase):
     def test_empty(self):
         """If empty path list provided, then return an empty string"""
         self.assertEqual(parsers._create_key([]), "")
@@ -92,7 +92,7 @@ class TestCreateKey(TestCase):
         self.assertEqual(res, "sample[m\xe9lange][k][2]")
 
 
-class TestInitData(TestCase):
+class TestInitData(SimpleTestCase):
     def test_int_new(self):
         """Test int key, that does NOT exist"""
         self.assertEqual(parsers._init_data([], 0, []), [[]])
@@ -113,7 +113,7 @@ class TestInitData(TestCase):
         )
 
 
-class TestBuildParsedData(TestCase):
+class TestBuildParsedData(SimpleTestCase):
     def test_dict(self):
         """Check handling of last element as a string, should result in
         dictionary"""
@@ -142,7 +142,7 @@ class TestBuildParsedData(TestCase):
         self.assertEqual(res, {"one": {"two": {"three": ["end"]}}})
 
 
-class TestParseMultipartData(TestCase):
+class TestParseMultipartData(SimpleTestCase):
     def test_empty(self):
         self.assertEqual(parsers.parse_multipart_data({}), {})
 

--- a/EquiTrack/EquiTrack/tests/test_utils.py
+++ b/EquiTrack/EquiTrack/tests/test_utils.py
@@ -2,14 +2,14 @@
 from __future__ import absolute_import, division, print_function
 
 from datetime import datetime
-from unittest import TestCase
 
+from django.test import SimpleTestCase
 from freezegun import freeze_time
 
 from EquiTrack.utils import get_current_year, get_quarter
 
 
-class TestUtils(TestCase):
+class TestUtils(SimpleTestCase):
     """
     Test utils function
     """

--- a/EquiTrack/EquiTrack/tests/test_validation_mixins.py
+++ b/EquiTrack/EquiTrack/tests/test_validation_mixins.py
@@ -3,14 +3,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 # Don't enable unicode_literals in this module until Python 3. Tests in this module rely on being able to create
 # both str and unicode literals.
 # from __future__ import unicode_literals
-from unittest import TestCase
-
+from django.test import SimpleTestCase
 from django.utils import six
 
 from EquiTrack.validation_mixins import _BaseStateError, BasicValidationError, StateValidError, TransitionError
 
 
-class TestExceptions(TestCase):
+class TestExceptions(SimpleTestCase):
     '''Tests behavior of the 3 exceptions defined in validation_mixins. StateValidError and TransitionError are
     tested through their base class _BaseStateError.
     '''
@@ -49,6 +48,6 @@ class TestExceptions(TestCase):
                       ('hello world', 'goodbye world'),
                       42,
                       object(),
-                      TestCase,):
+                      type(self),):
             with self.assertRaises(TypeError):
                 _BaseStateError(param)

--- a/EquiTrack/audit/tests/test_models.py
+++ b/EquiTrack/audit/tests/test_models.py
@@ -2,12 +2,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import datetime
 import sys
-from unittest import skipIf, TestCase
+from unittest import skipIf
 
 from django.core import mail
 from django.core.exceptions import ValidationError
 from django.core.management import call_command
 from django.db import connection
+from django.test import SimpleTestCase
 from django.utils import six
 
 from audit.models import (
@@ -77,7 +78,7 @@ class EngagementStaffMemberTestCase(BaseTenantTestCase):
 
 
 @skipIf(sys.version_info.major == 3, "This test can be deleted under Python 3")
-class TestStrUnicode(TestCase):
+class TestStrUnicode(SimpleTestCase):
     """
     Ensure calling six.binary_type() on model instances returns UTF8-encoded text
     and six.text_type() returns unicode.

--- a/EquiTrack/firms/tests/test_utils.py
+++ b/EquiTrack/firms/tests/test_utils.py
@@ -1,13 +1,12 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from unittest import TestCase
-
+from django.test import SimpleTestCase
 from django.utils import six
 
 from firms.utils import generate_username
 
 
-class UsernameGeneratorTestCase(TestCase):
+class UsernameGeneratorTestCase(SimpleTestCase):
     iterations = 10 ** 5
 
     def test_length(self):

--- a/EquiTrack/funds/tests/test_api.py
+++ b/EquiTrack/funds/tests/test_api.py
@@ -3,9 +3,9 @@ from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
-from unittest import TestCase
 
 from django.core.urlresolvers import reverse
+from django.test import SimpleTestCase
 from django.utils import six
 from rest_framework import status
 from tablib.core import Dataset
@@ -23,7 +23,7 @@ from funds.tests.factories import (
 from users.tests.factories import UserFactory
 
 
-class UrlsTestCase(URLAssertionMixin, TestCase):
+class UrlsTestCase(URLAssertionMixin, SimpleTestCase):
     '''Simple test case to verify URL reversal'''
     def test_urls(self):
         '''Verify URL pattern names generate the URLs we expect them to.'''

--- a/EquiTrack/locations/tests/test_models.py
+++ b/EquiTrack/locations/tests/test_models.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from django.test import SimpleTestCase
 from django.utils import six
-
-from unittest import TestCase
 
 from locations.tests.factories import (
     CartoDBTableFactory,
@@ -11,7 +10,7 @@ from locations.tests.factories import (
 )
 
 
-class TestStrUnicode(TestCase):
+class TestStrUnicode(SimpleTestCase):
     '''Ensure calling six.text_type() on model instances returns the right text.'''
     def test_gateway_type(self):
         gateway_type = GatewayTypeFactory.build(name=b'xyz')

--- a/EquiTrack/management/tests/test_api.py
+++ b/EquiTrack/management/tests/test_api.py
@@ -1,12 +1,12 @@
 # Python imports
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from unittest import TestCase
+from django.test import SimpleTestCase
 
 from EquiTrack.tests.mixins import URLAssertionMixin
 
 
-class UrlsTestCase(URLAssertionMixin, TestCase):
+class UrlsTestCase(URLAssertionMixin, SimpleTestCase):
     '''Simple test case to verify URL reversal'''
     def test_urls(self):
         '''Verify URL pattern names generate the URLs we expect them to.'''

--- a/EquiTrack/monitoring/tests/test_checks.py
+++ b/EquiTrack/monitoring/tests/test_checks.py
@@ -4,16 +4,17 @@ from __future__ import print_function
 from __future__ import unicode_literals
 
 from mock import patch, Mock
-from unittest import TestCase
 
 from django.conf import settings
 from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase
 
+from EquiTrack.tests.cases import BaseTenantTestCase
 from monitoring.service_checks import check_celery, check_db
 from users.tests.factories import UserFactory
 
 
-class TestCheckDB(TestCase):
+class TestCheckDB(BaseTenantTestCase):
     def test_no_users(self):
         # if --keepdb flag used Users probably exist in db
         # so ignore this test if that is the case
@@ -40,7 +41,7 @@ class TestCheckDB(TestCase):
         )
 
 
-class TestCheckCelery(TestCase):
+class TestCheckCelery(SimpleTestCase):
     def test_valid(self):
         mock_ping = Mock()
         mock_ping.control.ping.return_value = [1, 2]

--- a/EquiTrack/partners/tests/test_api_agreements.py
+++ b/EquiTrack/partners/tests/test_api_agreements.py
@@ -1,8 +1,8 @@
 from __future__ import unicode_literals
-from unittest import TestCase
 import json
 import datetime
 from django.core.urlresolvers import reverse
+from django.test import SimpleTestCase
 from rest_framework import status
 
 from EquiTrack.tests.cases import BaseTenantTestCase
@@ -23,7 +23,7 @@ from snapshot.models import Activity
 from users.tests.factories import GroupFactory, UserFactory
 
 
-class URLsTestCase(URLAssertionMixin, TestCase):
+class URLsTestCase(URLAssertionMixin, SimpleTestCase):
     '''Simple test case to verify URL reversal'''
     def test_urls(self):
         '''Verify URL pattern names generate the URLs we expect them to.'''

--- a/EquiTrack/partners/tests/test_api_interventions.py
+++ b/EquiTrack/partners/tests/test_api_interventions.py
@@ -2,12 +2,13 @@ from __future__ import unicode_literals
 
 import json
 import datetime
-from unittest import skip, TestCase
+from unittest import skip
 
 from django.contrib.auth.models import Group
 from django.core.cache import cache
 from django.core.urlresolvers import reverse, resolve
 from django.db import connection
+from django.test import SimpleTestCase
 from django.utils import six, timezone
 from django.core.files.uploadedfile import SimpleUploadedFile
 
@@ -55,7 +56,7 @@ def _add_user_to_partnership_manager_group(user):
     user.groups.add(group)
 
 
-class URLsTestCase(URLAssertionMixin, TestCase):
+class URLsTestCase(URLAssertionMixin, SimpleTestCase):
     '''Simple test case to verify URL reversal'''
     def test_urls(self):
         '''Verify URL pattern names generate the URLs we expect them to.'''

--- a/EquiTrack/partners/tests/test_api_partners.py
+++ b/EquiTrack/partners/tests/test_api_partners.py
@@ -4,9 +4,10 @@ import datetime
 import json
 
 from django.core.urlresolvers import reverse
+from django.test import SimpleTestCase
 from mock import patch, Mock
 from rest_framework import status
-from unittest import TestCase, skip
+from unittest import skip
 
 from EquiTrack.tests.cases import BaseTenantTestCase
 from EquiTrack.tests.mixins import URLAssertionMixin
@@ -23,7 +24,7 @@ from users.tests.factories import GroupFactory, UserFactory
 INSIGHT_PATH = "partners.views.partner_organization_v2.get_data_from_insight"
 
 
-class URLsTestCase(URLAssertionMixin, TestCase):
+class URLsTestCase(URLAssertionMixin, SimpleTestCase):
     '''Simple test case to verify URL reversal'''
     def test_urls(self):
         '''Verify URL pattern names generate the URLs we expect them to.'''

--- a/EquiTrack/partners/tests/test_api_pmp.py
+++ b/EquiTrack/partners/tests/test_api_pmp.py
@@ -3,9 +3,9 @@ from __future__ import division
 from __future__ import print_function
 from __future__ import unicode_literals
 import json
-from unittest import TestCase
 
 from django.core.urlresolvers import reverse
+from django.test import SimpleTestCase
 
 from rest_framework import status
 from tenant_schemas.test.client import TenantClient
@@ -28,7 +28,7 @@ from publics.tests.factories import PublicsCurrencyFactory
 from users.tests.factories import UserFactory
 
 
-class URLsTestCase(URLAssertionMixin, TestCase):
+class URLsTestCase(URLAssertionMixin, SimpleTestCase):
     '''Simple test case to verify URL reversal'''
     def test_urls(self):
         '''Verify URL pattern names generate the URLs we expect them to.'''

--- a/EquiTrack/partners/tests/test_models.py
+++ b/EquiTrack/partners/tests/test_models.py
@@ -2,9 +2,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import copy
 import datetime
-from unittest import TestCase, skip
+from unittest import skip
 
 from django.core.files.uploadedfile import SimpleUploadedFile
+from django.test import SimpleTestCase
 from django.utils import six, timezone
 from freezegun import freeze_time
 
@@ -1513,7 +1514,7 @@ class TestStrUnicodeSlow(BaseTenantTestCase):
         six.text_type(instance)
 
 
-class TestStrUnicode(TestCase):
+class TestStrUnicode(SimpleTestCase):
     '''Ensure calling six.text_type() on model instances returns the right text.'''
     def test_workspace_file_type(self):
         instance = WorkspaceFileTypeFactory.build(name='xyz')

--- a/EquiTrack/partners/tests/test_views.py
+++ b/EquiTrack/partners/tests/test_views.py
@@ -4,13 +4,14 @@ import csv
 import datetime
 from decimal import Decimal
 import json
-from unittest import skip, TestCase
+from unittest import skip
 from urlparse import urlparse
 
 from django.conf import settings
 from django.core.files.uploadedfile import SimpleUploadedFile
 from django.core.urlresolvers import reverse, resolve
 from django.db import connection
+from django.test import SimpleTestCase
 from django.utils import six, timezone
 
 from model_utils import Choices
@@ -65,7 +66,7 @@ from users.tests.factories import (
 )
 
 
-class URLsTestCase(URLAssertionMixin, TestCase):
+class URLsTestCase(URLAssertionMixin, SimpleTestCase):
     '''Simple test case to verify URL reversal'''
     def test_urls(self):
         '''Verify URL pattern names generate the URLs we expect them to.'''

--- a/EquiTrack/publics/tests/test_models.py
+++ b/EquiTrack/publics/tests/test_models.py
@@ -1,7 +1,6 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from unittest import TestCase
-
+from django.test import SimpleTestCase
 from django.utils import six
 
 from publics.tests.factories import (
@@ -19,7 +18,7 @@ from publics.tests.factories import (
 )
 
 
-class TestStrUnicode(TestCase):
+class TestStrUnicode(SimpleTestCase):
     '''Ensure calling six.text_type() on model instances returns the right text.'''
     def test_travel_expense_type(self):
         instance = PublicsTravelExpenseTypeFactory.build(title='xyz')

--- a/EquiTrack/reports/tests/test_models.py
+++ b/EquiTrack/reports/tests/test_models.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
-from unittest import TestCase
 
+from django.test import SimpleTestCase
 from django.utils import six
 
 from EquiTrack.tests.cases import BaseTenantTestCase
@@ -27,7 +27,7 @@ from reports.tests.factories import (
 from reports.tests.factories import QuarterFactory
 
 
-class TestStrUnicode(TestCase):
+class TestStrUnicode(SimpleTestCase):
     '''Ensure calling six.text_type() on model instances returns the right text.'''
     def test_country_programme(self):
         instance = CountryProgrammeFactory.build(name=b'xyz', wbs=b'xyz')

--- a/EquiTrack/reports/tests/test_views.py
+++ b/EquiTrack/reports/tests/test_views.py
@@ -1,9 +1,8 @@
 import datetime
 from operator import itemgetter
 
-from unittest import TestCase
-
 from django.core.urlresolvers import reverse
+from django.test import SimpleTestCase
 from django.utils import six
 from rest_framework import status
 from partners.tests.test_utils import setup_intervention_test_data
@@ -38,7 +37,7 @@ from reports.tests.factories import (
 from users.tests.factories import UserFactory
 
 
-class UrlsTestCase(URLAssertionMixin, TestCase):
+class UrlsTestCase(URLAssertionMixin, SimpleTestCase):
     '''Simple test case to verify URL reversal'''
     def test_urls(self):
         '''Verify URL pattern names generate the URLs we expect them to.'''

--- a/EquiTrack/users/tests/test_models.py
+++ b/EquiTrack/users/tests/test_models.py
@@ -1,8 +1,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from unittest import TestCase
-
 from django.contrib.auth import get_user_model
+from django.test import SimpleTestCase
 from django.utils import six
 
 from EquiTrack.tests.cases import BaseTenantTestCase
@@ -172,7 +171,7 @@ class TestDeletePartnerRelationship(BaseTenantTestCase):
         self.assertTrue(user_updated.is_active)
 
 
-class TestStrUnicode(TestCase):
+class TestStrUnicode(SimpleTestCase):
     '''Ensure calling six.text_type() on model instances returns the right text.'''
     def test_country(self):
         instance = CountryFactory.build(name=b'xyz')

--- a/EquiTrack/vision/tests/test_client.py
+++ b/EquiTrack/vision/tests/test_client.py
@@ -1,11 +1,11 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from unittest import TestCase
+from django.test import SimpleTestCase
 
 from vision import client
 
 
-class TestVisionClient(TestCase):
+class TestVisionClient(SimpleTestCase):
     def setUp(self):
         self.client = client.VisionAPIClient()
 

--- a/EquiTrack/vision/tests/test_models.py
+++ b/EquiTrack/vision/tests/test_models.py
@@ -1,14 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from unittest import TestCase
-
+from django.test import SimpleTestCase
 from django.utils import six
 
 from users.tests.factories import CountryFactory
 from vision.models import VisionSyncLog
 
 
-class TestStrUnicode(TestCase):
+class TestStrUnicode(SimpleTestCase):
     '''Ensure calling six.text_type() on model instances returns the right text.'''
 
     def test_vision_sync_log(self):

--- a/EquiTrack/vision/tests/test_tasks.py
+++ b/EquiTrack/vision/tests/test_tasks.py
@@ -227,7 +227,7 @@ class TestVisionSyncTask(SimpleTestCase):
         self._assertLoggerMessages(mock_logger, selected_countries, selected_synchronizers)
 
 
-class TestSyncHandlerTask(SimpleTestCase):
+class TestSyncHandlerTask(BaseTenantTestCase):
     """Exercises the sync_handler()"""
     def setUp(self):
         self.country = _build_country('My')

--- a/EquiTrack/vision/tests/test_tasks.py
+++ b/EquiTrack/vision/tests/test_tasks.py
@@ -2,8 +2,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
-from unittest import TestCase
 
+from django.test import SimpleTestCase
 from django.test.utils import override_settings
 from django.utils import timezone
 
@@ -38,7 +38,7 @@ def _build_country(name):
 @mock.patch('vision.tasks.sync_handler')
 @mock.patch('vision.tasks.connection', spec=['set_tenant'])
 @mock.patch('vision.tasks.logger.info')
-class TestVisionSyncTask(TestCase):
+class TestVisionSyncTask(SimpleTestCase):
     """Exercises the vision_sync_task() task which requires a lot of mocking and some monkey patching."""
     def setUp(self):
         super(TestVisionSyncTask, self).setUp()
@@ -227,7 +227,7 @@ class TestVisionSyncTask(TestCase):
         self._assertLoggerMessages(mock_logger, selected_countries, selected_synchronizers)
 
 
-class TestSyncHandlerTask(TestCase):
+class TestSyncHandlerTask(SimpleTestCase):
     """Exercises the sync_handler()"""
     def setUp(self):
         self.country = _build_country('My')

--- a/EquiTrack/vision/tests/test_utils.py
+++ b/EquiTrack/vision/tests/test_utils.py
@@ -1,12 +1,13 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
-from unittest import TestCase
+
+from django.test import SimpleTestCase
 
 from vision import utils
 
 
-class TestWCFJSONDateAsDatetime(TestCase):
+class TestWCFJSONDateAsDatetime(SimpleTestCase):
     def test_none(self):
         self.assertIsNone(utils.wcf_json_date_as_datetime(None))
 
@@ -32,7 +33,7 @@ class TestWCFJSONDateAsDatetime(TestCase):
         )
 
 
-class TestWCFJSONDateAsDate(TestCase):
+class TestWCFJSONDateAsDate(SimpleTestCase):
     def test_none(self):
         self.assertIsNone(utils.wcf_json_date_as_date(None))
 
@@ -58,7 +59,7 @@ class TestWCFJSONDateAsDate(TestCase):
         )
 
 
-class TestCompDecimals(TestCase):
+class TestCompDecimals(SimpleTestCase):
     def test_not_equal(self):
         self.assertFalse(utils.comp_decimals(0.2, 0.3))
 


### PR DESCRIPTION
Fix test that dirties the database, breaking --keepdb.

monitoring.tests.test_checks.TestCheckDB creates user objects,
but was subclassing unittest.TestCase. Change to BaseTenantTestCase.

The rest of the changes are to other tests that were using
unittest.TestCase. Changing them to django.tests.SimpleTestCase
will result in the tests failing if anything in them changes the
database, so we'll know they need to be changed to BaseTenantTestCase.

Also use BaseTenantTestCase for one vision test that fails otherwise (not
sure why)