### PR TITLE
Fix for swagger exception

### DIFF
--- a/EquiTrack/partners/tests/test_api_interventions.py
+++ b/EquiTrack/partners/tests/test_api_interventions.py
@@ -77,6 +77,20 @@ class URLsTestCase(URLAssertionMixin, TestCase):
         self.assertIntParamRegexes(names_and_paths, 'partners_api:')
 
 
+class TestInterventionsSwagger(BaseTenantTestCase):
+    def test_accessing_css_file(self):
+        # Because a swagger bug was breaking this (in combination with
+        # a particular way we had designed some URLs), this test is to
+        # reproduce the problem, then make sure the changes we make fix it.
+        # The swagger bug:
+        # https://github.com/marcgibbons/django-rest-swagger/issues/702
+        # was tickled by our having URLs that end in delete, maybe in
+        # combination with having their only method be 'delete'.
+        unicef_staff = UserFactory(is_staff=True)
+        response = self.forced_auth_req('get', '/api/docs/css/dashboard.css', user=unicef_staff)
+        self.assertEqual(200, response.status_code)
+
+
 class TestInterventionsAPI(BaseTenantTestCase):
     EDITABLE_FIELDS = {
         'draft': ["status", "attachments", "prc_review_document", 'travel_activities',

--- a/EquiTrack/partners/urls_v2.py
+++ b/EquiTrack/partners/urls_v2.py
@@ -52,7 +52,7 @@ urlpatterns = (
     url(r'^agreements/(?P<pk>\d+)/$', view=AgreementDetailAPIView.as_view(http_method_names=['get', 'patch']),
         name='agreement-detail'),
 
-    url(r'^agreements/(?P<pk>\d+)/delete/$', view=AgreementDeleteView.as_view(http_method_names=['delete']),
+    url(r'^agreements/(?P<pk>\d+)/$', view=AgreementDeleteView.as_view(http_method_names=['delete']),
         name='agreement-delete'),
 
     url(r'^agreements/(?P<agr>\d+)/generate_doc/$', PCAPDFView.as_view(), name='pca_pdf'),
@@ -140,7 +140,7 @@ urlpatterns = (
     url(r'^interventions/(?P<pk>\d+)/$',
         view=InterventionDetailAPIView.as_view(http_method_names=['get', 'patch']),
         name='intervention-detail'),
-    url(r'^interventions/(?P<pk>\d+)/delete/$',
+    url(r'^interventions/(?P<pk>\d+)/$',
         view=InterventionDeleteView.as_view(http_method_names=['delete']),
         name='intervention-delete'),
 

--- a/EquiTrack/partners/urls_v2.py
+++ b/EquiTrack/partners/urls_v2.py
@@ -52,7 +52,7 @@ urlpatterns = (
     url(r'^agreements/(?P<pk>\d+)/$', view=AgreementDetailAPIView.as_view(http_method_names=['get', 'patch']),
         name='agreement-detail'),
 
-    url(r'^agreements/(?P<pk>\d+)/$', view=AgreementDeleteView.as_view(http_method_names=['delete']),
+    url(r'^agreements/delete/(?P<pk>\d+)/$', view=AgreementDeleteView.as_view(http_method_names=['delete']),
         name='agreement-delete'),
 
     url(r'^agreements/(?P<agr>\d+)/generate_doc/$', PCAPDFView.as_view(), name='pca_pdf'),
@@ -140,7 +140,7 @@ urlpatterns = (
     url(r'^interventions/(?P<pk>\d+)/$',
         view=InterventionDetailAPIView.as_view(http_method_names=['get', 'patch']),
         name='intervention-detail'),
-    url(r'^interventions/(?P<pk>\d+)/$',
+    url(r'^interventions/delete/(?P<pk>\d+)/$',
         view=InterventionDeleteView.as_view(http_method_names=['delete']),
         name='intervention-delete'),
 


### PR DESCRIPTION
[ch4968] This adds a test to reproduce the problem we were seeing,
then changes a couple of URLs in the API so it stops happening.

Warning: this could be a breaking change if anyone is already
using these API endpoints. But they are quite new, so hopefully
not.

See also:

* https://app.clubhouse.io/unicefetools/story/4968/swagger-issue-typeerror-link-object-does-not-support-item-assignment
* https://github.com/marcgibbons/django-rest-swagger/issues/702