### PR TITLE
Django 1.11 warnings fix for Auditor portal & TPM.

### DIFF
--- a/EquiTrack/audit/migrations/0001_initial.py
+++ b/EquiTrack/audit/migrations/0001_initial.py
@@ -73,6 +73,7 @@ class Migration(migrations.Migration):
                 ('cancel_comment', models.TextField(blank=True, verbose_name='Cancel Comment')),
             ],
             options={
+                'ordering': ('id', ),
                 'verbose_name': 'Engagement',
                 'verbose_name_plural': 'Engagements',
             },
@@ -189,6 +190,7 @@ class Migration(migrations.Migration):
                 ('audit_opinion', models.CharField(blank=True, choices=[('unqualified', 'Unqualified'), ('qualified', 'Qualified'), ('disclaimer_opinion', 'Disclaimer opinion'), ('adverse_opinion', 'Adverse opinion')], max_length=20, null=True, verbose_name='Audit Opinion')),
             ],
             options={
+                'ordering': ('id',),
                 'verbose_name': 'Audit',
                 'verbose_name_plural': 'Audits',
             },
@@ -200,6 +202,7 @@ class Migration(migrations.Migration):
                 ('engagement_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='audit.Engagement')),
             ],
             options={
+                'ordering': ('id',),
                 'verbose_name': 'Micro Assessment',
                 'verbose_name_plural': 'Micro Assessments',
             },
@@ -211,7 +214,10 @@ class Migration(migrations.Migration):
                 ('engagement_ptr', models.OneToOneField(auto_created=True, on_delete=django.db.models.deletion.CASCADE, parent_link=True, primary_key=True, serialize=False, to='audit.Engagement')),
             ],
             options={
+                'ordering': ('id',),
                 'abstract': False,
+                'verbose_name': 'Special Audit',
+                'verbose_name_plural': 'Special Audits',
             },
             bases=('audit.engagement',),
         ),
@@ -224,6 +230,7 @@ class Migration(migrations.Migration):
                 ('internal_controls', models.TextField(blank=True, verbose_name='Internal Controls')),
             ],
             options={
+                'ordering': ('id',),
                 'verbose_name': 'Spot Check',
                 'verbose_name_plural': 'Spot Checks',
             },

--- a/EquiTrack/audit/models.py
+++ b/EquiTrack/audit/models.py
@@ -360,6 +360,8 @@ class SpotCheck(Engagement):
 
     internal_controls = models.TextField(verbose_name=_('Internal Controls'), blank=True)
 
+    objects = models.Manager()
+
     class Meta:
         ordering = ('id', )
         verbose_name = _('Spot Check')
@@ -465,6 +467,8 @@ class Finding(models.Model):
 
 @python_2_unicode_compatible
 class MicroAssessment(Engagement):
+    objects = models.Manager()
+
     class Meta:
         ordering = ('id',)
         verbose_name = _('Micro Assessment')
@@ -530,6 +534,8 @@ class Audit(Engagement):
     audit_opinion = models.CharField(
         verbose_name=_('Audit Opinion'), max_length=20, choices=OPTIONS, default='', blank=True,
     )
+
+    objects = models.Manager()
 
     class Meta:
         ordering = ('id',)
@@ -636,6 +642,8 @@ class KeyInternalControl(models.Model):
 
 @python_2_unicode_compatible
 class SpecialAudit(Engagement):
+    objects = models.Manager()
+
     class Meta:
         ordering = ('id', )
         verbose_name = _('Special Audit')

--- a/EquiTrack/audit/models.py
+++ b/EquiTrack/audit/models.py
@@ -166,6 +166,7 @@ class Engagement(TimeStampedModel, models.Model):
     objects = InheritanceManager()
 
     class Meta:
+        ordering = ('id',)
         verbose_name = _('Engagement')
         verbose_name_plural = _('Engagements')
 
@@ -360,6 +361,7 @@ class SpotCheck(Engagement):
     internal_controls = models.TextField(verbose_name=_('Internal Controls'), blank=True)
 
     class Meta:
+        ordering = ('id', )
         verbose_name = _('Spot Check')
         verbose_name_plural = _('Spot Checks')
 
@@ -464,6 +466,7 @@ class Finding(models.Model):
 @python_2_unicode_compatible
 class MicroAssessment(Engagement):
     class Meta:
+        ordering = ('id',)
         verbose_name = _('Micro Assessment')
         verbose_name_plural = _('Micro Assessments')
 
@@ -529,6 +532,7 @@ class Audit(Engagement):
     )
 
     class Meta:
+        ordering = ('id',)
         verbose_name = _('Audit')
         verbose_name_plural = _('Audits')
 
@@ -632,6 +636,11 @@ class KeyInternalControl(models.Model):
 
 @python_2_unicode_compatible
 class SpecialAudit(Engagement):
+    class Meta:
+        ordering = ('id', )
+        verbose_name = _('Special Audit')
+        verbose_name_plural = _('Special Audits')
+
     def save(self, *args, **kwargs):
         self.engagement_type = Engagement.TYPES.sa
         return super(SpecialAudit, self).save(*args, **kwargs)

--- a/EquiTrack/audit/purchase_order/migrations/0001_initial.py
+++ b/EquiTrack/audit/purchase_order/migrations/0001_initial.py
@@ -39,6 +39,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'abstract': False,
+                'ordering': ('id',),
                 'verbose_name': 'Organization',
                 'verbose_name_plural': 'Organizations',
             },
@@ -52,6 +53,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'abstract': False,
+                'ordering': ('id',),
                 'verbose_name': 'Staff Member',
                 'verbose_name_plural': 'Staff Members',
             },

--- a/EquiTrack/firms/models.py
+++ b/EquiTrack/firms/models.py
@@ -68,6 +68,7 @@ class BaseFirm(TimeStampedModel, models.Model):
 
     class Meta:
         abstract = True
+        ordering = ('id',)
         verbose_name = _('Organization')
         verbose_name_plural = _('Organizations')
 
@@ -88,6 +89,7 @@ class BaseStaffMember(models.Model):
 
     class Meta:
         abstract = True
+        ordering = ('id',)
         verbose_name = _('Staff Member')
         verbose_name_plural = _('Staff Members')
 

--- a/EquiTrack/tpm/migrations/0001_initial.py
+++ b/EquiTrack/tpm/migrations/0001_initial.py
@@ -96,6 +96,9 @@ class Migration(migrations.Migration):
             ],
             options={
                 'abstract': False,
+                'ordering': ('id',),
+                'verbose_name': 'TPM Visit',
+                'verbose_name_plural': 'TPM Visits'
             },
             managers=[
                 ('admin_objects', django.db.models.manager.Manager()),

--- a/EquiTrack/tpm/models.py
+++ b/EquiTrack/tpm/models.py
@@ -99,6 +99,11 @@ class TPMVisit(SoftDeleteMixin, TimeStampedModel, models.Model):
 
     tpm_partner_tracker = FieldTracker(fields=['tpm_partner', ])
 
+    class Meta:
+        ordering = ('id',)
+        verbose_name = _('TPM Visit')
+        verbose_name_plural = _('TPM Visits')
+
     @property
     def date_created(self):
         return self.created.date()

--- a/EquiTrack/tpm/tpmpartners/migrations/0001_initial.py
+++ b/EquiTrack/tpm/tpmpartners/migrations/0001_initial.py
@@ -39,6 +39,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'abstract': False,
+                'ordering': ('id',),
                 'verbose_name': 'Organization',
                 'verbose_name_plural': 'Organizations',
             },
@@ -53,6 +54,7 @@ class Migration(migrations.Migration):
             ],
             options={
                 'abstract': False,
+                'ordering': ('id',),
                 'verbose_name': 'Staff Member',
                 'verbose_name_plural': 'Staff Members',
             },


### PR DESCRIPTION
Set default ordering for paginated models. Modified initial migrations for easier integration with other branches, containing migrations (auditor-portal, auditor-portal-new-migrations) as there is no real changes to database.
Explicitly set default manager for models inherited from Engagement.