### PR TITLE
Upgrade djangosaml2 (and pysaml2)

### DIFF
--- a/EquiTrack/EquiTrack/settings/base.py
+++ b/EquiTrack/EquiTrack/settings/base.py
@@ -403,7 +403,7 @@ SAML_CONFIG = {
             'name': 'eTools',
             'name_id_format': saml.NAMEID_FORMAT_PERSISTENT,
             'endpoints': {
-                # url and binding to the assetion consumer service view
+                # url and binding to the assertion consumer service view
                 # do not change the binding or service name
                 'assertion_consumer_service': [
                     ('https://{}/saml2/acs/'.format(HOST),
@@ -422,6 +422,10 @@ SAML_CONFIG = {
 
             # attributes that this project needs to identify a user
             'required_attributes': ['upn', 'emailAddress'],
+
+            # Default for this value changed from False to True, so explicitly set it as False
+            # https://pysaml2.readthedocs.io/en/latest/howto/config.html#want-response-signed
+            'want_response_signed': False,
         },
     },
     # where the remote metadata is stored

--- a/EquiTrack/requirements/base.txt
+++ b/EquiTrack/requirements/base.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/robertavram/django-storages.git@1.6.5.3#egg=django-storages
--e git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
+-e git+https://github.com/unicef/djangosaml2.git@v0.16.11.3#egg=djangosaml2
 amqp==2.2.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 azure-common==1.1.8       # via azure-storage

--- a/EquiTrack/requirements/input/base.in
+++ b/EquiTrack/requirements/input/base.in
@@ -46,5 +46,5 @@ psycopg2==2.7.4
 raven==6.2.1
 tenant-schemas-celery==0.1.7
 
--e git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
+-e git+https://github.com/unicef/djangosaml2.git@v0.16.11.3#egg=djangosaml2
 -e git+https://github.com/robertavram/django-storages.git@1.6.5.3#egg=django-storages

--- a/EquiTrack/requirements/local.txt
+++ b/EquiTrack/requirements/local.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/robertavram/django-storages.git@1.6.5.3#egg=django-storages
--e git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
+-e git+https://github.com/unicef/djangosaml2.git@v0.16.11.3#egg=djangosaml2
 alabaster==0.7.10         # via sphinx
 amqp==2.2.2
 asn1crypto==0.24.0

--- a/EquiTrack/requirements/production.txt
+++ b/EquiTrack/requirements/production.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/robertavram/django-storages.git@1.6.5.3#egg=django-storages
--e git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
+-e git+https://github.com/unicef/djangosaml2.git@v0.16.11.3#egg=djangosaml2
 amqp==2.2.2
 asn1crypto==0.24.0
 azure-common==1.1.8

--- a/EquiTrack/requirements/test.txt
+++ b/EquiTrack/requirements/test.txt
@@ -1,5 +1,5 @@
 -e git+https://github.com/robertavram/django-storages.git@1.6.5.3#egg=django-storages
--e git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
+-e git+https://github.com/unicef/djangosaml2.git@v0.16.11.3#egg=djangosaml2
 amqp==2.2.2
 asn1crypto==0.24.0
 azure-common==1.1.8


### PR DESCRIPTION
[ch5204]

This will depend on this PR being approved first: https://github.com/unicef/djangosaml2/pull/1/

Marking as 'READY' for review, but I expect CI to fail, since the djangosaml2 release that I referenced doesn't exist yet.

