### PR TITLE
Fix copy attachments partner task

### DIFF
--- a/EquiTrack/partners/tasks.py
+++ b/EquiTrack/partners/tasks.py
@@ -319,4 +319,4 @@ def pmp_indicator_report():
 @app.task
 def copy_attachments(hours=25):
     """Copy all partner app attachments"""
-    copy_all_attachments(hours)
+    copy_all_attachments(hours=hours)

--- a/EquiTrack/partners/tests/test_tasks.py
+++ b/EquiTrack/partners/tests/test_tasks.py
@@ -10,11 +10,20 @@ from django.utils import six, timezone
 
 import mock
 
+from attachments.models import Attachment
+from attachments.tests.factories import (
+    AttachmentFactory,
+    AttachmentFileTypeFactory,
+)
 from EquiTrack.tests.cases import BaseTenantTestCase
 from funds.tests.factories import FundsReservationHeaderFactory
 from partners.models import Agreement, Intervention
 import partners.tasks
-from partners.tests.factories import AgreementFactory, InterventionFactory
+from partners.tests.factories import (
+    AgreementFactory,
+    InterventionFactory,
+    PartnerFactory,
+)
 from users.models import User
 from users.tests.factories import CountryFactory, UserFactory
 
@@ -762,3 +771,28 @@ class TestNotifyOfInterventionsEndingSoon(PartnersTestBaseClass):
         # Verify that each created notification object had send_notification() called.
         expected_call_args = [((), {}) for intervention in interventions]
         self._assertCalls(mock_notification.send_notification, expected_call_args)
+
+
+class TestCopyAttachments(BaseTenantTestCase):
+    @classmethod
+    def setUpTestData(cls):
+        cls.file_type_partner = AttachmentFileTypeFactory(
+            code="partners_partner_assessment"
+        )
+        cls.partner = PartnerFactory(
+            core_values_assessment="sample.pdf"
+        )
+
+    def test_call(self):
+        attachment = AttachmentFactory(
+            content_object=self.partner,
+            file_type=self.file_type_partner,
+            code=self.file_type_partner.code,
+            file="random.pdf"
+        )
+        partners.tasks.copy_attachments()
+        attachment_update = Attachment.objects.get(pk=attachment.pk)
+        self.assertEqual(
+            attachment_update.file.name,
+            self.partner.core_values_assessment.name
+        )


### PR DESCRIPTION
Update the parameter in `copy_all_attachments` call in parnters tasks