### PR TITLE
[ch5698] Add HACT update button to country page

### DIFF
--- a/src/etools/applications/users/admin.py
+++ b/src/etools/applications/users/admin.py
@@ -286,7 +286,7 @@ class CountryAdmin(admin.ModelAdmin):
     @staticmethod
     def execute_sync(country_pk, synchronizer):
         country = Country.objects.get(pk=country_pk)
-        if country.schema_name == 'public':
+        if country.schema_name == get_public_schema_name():
             vision_sync_task(synchronizers=[synchronizer, ])
         else:
             sync_handler.delay(country.name, synchronizer)

--- a/src/etools/applications/users/admin.py
+++ b/src/etools/applications/users/admin.py
@@ -237,7 +237,6 @@ class CountryAdmin(admin.ModelAdmin):
 
     list_display = (
         'name',
-        'schema_name',
         'country_short_code',
         'business_area_code',
         'vision_sync_enabled',

--- a/src/etools/applications/users/templates/admin/users/country/change_form.html
+++ b/src/etools/applications/users/templates/admin/users/country/change_form.html
@@ -6,6 +6,7 @@
     <li><a href="{% url 'admin:users_country_ram' original.id %}" style="background-color:#0099ff">{% trans "Sync RAM" %}</a></li>
     <li><a href="{% url 'admin:users_country_fund_reservation' original.id %}" style="background-color:#0099ff">{% trans "Sync Fund Reservation" %}</a></li>
     <li><a href="{% url 'admin:users_country_fund_commitment' original.id %}" style="background-color:#0099ff">{% trans "Sync Fund Commitment" %}</a></li>
+    <li><a href="{% url 'admin:users_country_update_hact' original.id %}" style="background-color:#ff3d00">{% trans "Update HACT" %}</a></li>
 
     <li><a target='_blank' href="https://devapis.unicef.org/BIService/BIWebService.svc/GetPartnerDetailsInfo_xml/{{original.business_area_code}}" style="background-color:#96c525">{% trans "API Partner" %}</a></li>
     <li><a target='_blank' href="https://devapis.unicef.org/BIService/BIWebService.svc/GetProgrammeStructureList_xml/{{original.business_area_code}}" style="background-color:#96c525">{% trans "API Programme" %}</a></li>


### PR DESCRIPTION
On the change page in the admin for the users Country model, add a
button that updates the HACT values for the current country, or if the
current country is the global/public country, schedules tasks to
update all the countries.