### PR TITLE
Remove django-geojson again!

### DIFF
--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -31,7 +31,6 @@ django-easy-pdf==0.1.1
 django-filter==1.0.2
 django-fsm==2.4.0
 django-generic-links==0.4.0
-django-geojson==2.11
 django-hstore==1.4.2      # via djangorestframework-hstore
 django-import-export==1.0
 django-js-asset==1.1.0    # via django-mptt
@@ -91,7 +90,7 @@ reportlab==3.3.0          # via django-easy-pdf, xhtml2pdf
 repoze.who==2.3           # via pysaml2
 requests==2.11.1          # via azure-storage, carto, coreapi, djrill, pyrestcli, pysaml2
 simplejson==3.13.2        # via django-rest-swagger
-six==1.11.0               # via cryptography, django-geojson, djangorestframework-csv, html5lib, paste, pyopenssl, pysaml2, python-dateutil, xhtml2pdf
+six==1.11.0               # via cryptography, djangorestframework-csv, html5lib, paste, pyopenssl, pysaml2, python-dateutil, xhtml2pdf
 sqlparse==0.2.4           # via django-debug-toolbar
 static3==0.7.0            # via dj-static
 tablib==0.12.1            # via django-import-export

--- a/src/requirements/input/base.in
+++ b/src/requirements/input/base.in
@@ -22,7 +22,6 @@ django-filter==1.0.2
 django-fsm==2.4.0
 django-import-export==1.0
 django-generic-links==0.4.0
-django-geojson==2.11
 django-leaflet==0.23
 django-logentry-admin==1.0.3
 django-model-utils==2.6

--- a/src/requirements/local.txt
+++ b/src/requirements/local.txt
@@ -36,7 +36,6 @@ django-extensions==1.9.7
 django-filter==1.0.2
 django-fsm==2.4.0
 django-generic-links==0.4.0
-django-geojson==2.11
 django-hstore==1.4.2
 django-import-export==1.0
 django-js-asset==1.1.0

--- a/src/requirements/production.txt
+++ b/src/requirements/production.txt
@@ -31,7 +31,6 @@ django-easy-pdf==0.1.1
 django-filter==1.0.2
 django-fsm==2.4.0
 django-generic-links==0.4.0
-django-geojson==2.11
 django-hstore==1.4.2
 django-import-export==1.0
 django-js-asset==1.1.0

--- a/src/requirements/test.txt
+++ b/src/requirements/test.txt
@@ -34,7 +34,6 @@ django-easy-pdf==0.1.1
 django-filter==1.0.2
 django-fsm==2.4.0
 django-generic-links==0.4.0
-django-geojson==2.11
 django-hstore==1.4.2
 django-import-export==1.0
 django-js-asset==1.1.0


### PR DESCRIPTION
Part of [ch5697]

We removed it in #1009, but looks like it snuck back in during #1019, accidentally, I think (since both of those PRs were created around the same time, but the second one didn't get merged til much later)