### PR TITLE
Allow planned visit hact values to be set for government types

### DIFF
--- a/src/etools/applications/partners/models.py
+++ b/src/etools/applications/partners/models.py
@@ -643,17 +643,14 @@ class PartnerOrganization(TimeStampedModel):
         If partner type is Government, then default to 0 planned visits
         """
         year = datetime.date.today().year
-        if self.partner_type == 'Government':
+        try:
+            pv = self.planned_visits.get(year=year)
+            pvq1 = pv.programmatic_q1
+            pvq2 = pv.programmatic_q2
+            pvq3 = pv.programmatic_q3
+            pvq4 = pv.programmatic_q4
+        except PartnerPlannedVisits.DoesNotExist:
             pvq1 = pvq2 = pvq3 = pvq4 = 0
-        else:
-            try:
-                pv = self.planned_visits.get(year=year)
-                pvq1 = pv.programmatic_q1
-                pvq2 = pv.programmatic_q2
-                pvq3 = pv.programmatic_q3
-                pvq4 = pv.programmatic_q4
-            except PartnerPlannedVisits.DoesNotExist:
-                pvq1 = pvq2 = pvq3 = pvq4 = 0
 
         hact = json.loads(self.hact_values) \
             if isinstance(self.hact_values, six.text_type) \

--- a/src/etools/applications/partners/tests/test_models.py
+++ b/src/etools/applications/partners/tests/test_models.py
@@ -389,7 +389,7 @@ class TestPartnerOrganizationModel(BaseTenantTestCase):
         )
         self.assertEqual(
             self.partner_organization.hact_values['programmatic_visits']['planned']['total'],
-            0
+            3
         )
 
     def test_planned_visits_non_gov(self):


### PR DESCRIPTION
[ch5982]

Government type orgnizations can not set planned visit hact values.