### PR TITLE
API Checker trial

### DIFF
--- a/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestAPIAgreements/api_v2_agreements.response.json
+++ b/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestAPIAgreements/api_v2_agreements.response.json
@@ -20,6 +20,19 @@
     },
     "data": [
         {
+            "id": 1,
+            "partner": 1,
+            "agreement_number": "TST/PCA20181",
+            "partner_name": "Partner 0",
+            "agreement_type": "PCA",
+            "end": "2018-12-31",
+            "start": "2018-06-15",
+            "signed_by_unicef_date": "2018-06-15",
+            "signed_by_partner_date": "2018-06-15",
+            "status": "signed",
+            "signed_by": null
+        },
+        {
             "id": 5,
             "partner": 5,
             "agreement_number": "TST/PCA20185",

--- a/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestAPIAgreements/api_v2_agreements_amendments.response.json
+++ b/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestAPIAgreements/api_v2_agreements_amendments.response.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200,
+    "headers": {
+        "content-type": [
+            "Content-Type",
+            "application/json"
+        ],
+        "vary": [
+            "Vary",
+            "Accept, Cookie"
+        ],
+        "allow": [
+            "Allow",
+            "GET, HEAD, OPTIONS"
+        ],
+        "x-frame-options": [
+            "X-Frame-Options",
+            "SAMEORIGIN"
+        ]
+    },
+    "data": [
+        {
+            "id": 1,
+            "created": "2018-06-15T02:05:14.044000Z",
+            "modified": "2018-06-15T02:05:14.046000Z",
+            "number": "tmp01",
+            "signed_amendment": null,
+            "types": [
+                "Change in clause"
+            ],
+            "signed_date": null,
+            "agreement": 1
+        }
+    ],
+    "content_type": null
+}

--- a/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestAPIAgreements/fixtures.json
+++ b/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestAPIAgreements/fixtures.json
@@ -115,5 +115,135 @@
                 }
             }
         ]
+    },
+    "agreement_amendment": {
+        "master": {
+            "model": "partners.agreementamendment",
+            "pk": 1,
+            "fields": {
+                "created": "2018-06-15T02:05:14.044Z",
+                "modified": "2018-06-15T02:05:14.046Z",
+                "number": "tmp01",
+                "agreement": 1,
+                "signed_amendment": "",
+                "types": "[\"Change in clause\"]",
+                "signed_date": null
+            }
+        },
+        "deps": [
+            {
+                "model": "partners.agreement",
+                "pk": 1,
+                "fields": {
+                    "created": "2018-06-15T02:05:14.040Z",
+                    "modified": "2018-06-15T02:05:14.042Z",
+                    "partner": 1,
+                    "country_programme": 1,
+                    "agreement_type": "PCA",
+                    "agreement_number": "TST/PCA20181",
+                    "attached_agreement": "test/file_attachments/partner_organization/1/agreements/test_file_pda1vOc.pdf",
+                    "start": "2018-06-15",
+                    "end": "2018-12-31",
+                    "signed_by_unicef_date": "2018-06-15",
+                    "signed_by": null,
+                    "signed_by_partner_date": "2018-06-15",
+                    "partner_manager": null,
+                    "status": "signed",
+                    "authorized_officers": []
+                }
+            },
+            {
+                "model": "partners.partnerorganization",
+                "pk": 1,
+                "fields": {
+                    "created": "2018-06-15T02:05:14.033Z",
+                    "modified": "2018-06-15T02:05:14.037Z",
+                    "partner_type": "",
+                    "cso_type": null,
+                    "name": "Partner 0",
+                    "short_name": "",
+                    "description": "",
+                    "shared_with": null,
+                    "street_address": null,
+                    "city": null,
+                    "postal_code": null,
+                    "country": null,
+                    "address": null,
+                    "email": null,
+                    "phone_number": null,
+                    "vendor_number": null,
+                    "alternate_id": null,
+                    "alternate_name": null,
+                    "rating": null,
+                    "type_of_assessment": null,
+                    "last_assessment_date": null,
+                    "core_values_assessment_date": null,
+                    "core_values_assessment": "",
+                    "vision_synced": false,
+                    "blocked": false,
+                    "deleted_flag": false,
+                    "manually_blocked": false,
+                    "hidden": false,
+                    "total_ct_cp": null,
+                    "total_ct_cy": null,
+                    "net_ct_cy": null,
+                    "reported_cy": null,
+                    "total_ct_ytd": null,
+                    "hact_values": {
+                        "audits": {
+                            "completed": 0,
+                            "minimum_requirements": 0
+                        },
+                        "spot_checks": {
+                            "planned": {
+                                "q1": 0,
+                                "q2": 0,
+                                "q3": 0,
+                                "q4": 0,
+                                "total": 0
+                            },
+                            "completed": {
+                                "q1": 0,
+                                "q2": 0,
+                                "q3": 0,
+                                "q4": 0,
+                                "total": 0
+                            },
+                            "follow_up_required": 0
+                        },
+                        "assurance_coverage": "void",
+                        "programmatic_visits": {
+                            "planned": {
+                                "q1": 0,
+                                "q2": 0,
+                                "q3": 0,
+                                "q4": 0,
+                                "total": 0
+                            },
+                            "completed": {
+                                "q1": 0,
+                                "q2": 0,
+                                "q3": 0,
+                                "q4": 0,
+                                "total": 0
+                            }
+                        },
+                        "outstanding_findings": 0
+                    },
+                    "basis_for_risk_rating": ""
+                }
+            },
+            {
+                "model": "reports.countryprogramme",
+                "pk": 1,
+                "fields": {
+                    "name": "Country Programme 0",
+                    "wbs": "0000/A0/00",
+                    "invalid": false,
+                    "from_date": "2018-01-01",
+                    "to_date": "2018-12-31"
+                }
+            }
+        ]
     }
 }

--- a/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestPartners/api_v2_partners_not_programmatic_visit.response.json
+++ b/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestPartners/api_v2_partners_not_programmatic_visit.response.json
@@ -45,33 +45,6 @@
             "total_ct_ytd": null,
             "hidden": false,
             "basis_for_risk_rating": ""
-        },
-        {
-            "street_address": null,
-            "last_assessment_date": null,
-            "address": null,
-            "city": null,
-            "postal_code": null,
-            "country": null,
-            "id": 101,
-            "vendor_number": "DDD",
-            "deleted_flag": false,
-            "blocked": false,
-            "name": "Partner 4",
-            "short_name": "Short name",
-            "partner_type": "Civil Society Organization",
-            "cso_type": "International",
-            "rating": null,
-            "shared_with": null,
-            "email": null,
-            "phone_number": null,
-            "total_ct_cp": null,
-            "total_ct_cy": null,
-            "net_ct_cy": null,
-            "reported_cy": null,
-            "total_ct_ytd": null,
-            "hidden": false,
-            "basis_for_risk_rating": ""
         }
     ],
     "content_type": null

--- a/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestPartners/fixtures.json
+++ b/src/etools/applications/partners/tests/_api_checker/etools.applications.partners.tests.test_api/TestPartners/fixtures.json
@@ -82,5 +82,55 @@
             }
         },
         "deps": []
+    },
+    "partner_not_programmatic_visit_compliant": {
+        "master": {
+            "model": "partners.partnerorganization",
+            "pk": 1,
+            "fields": {
+                "created": "2018-06-18T17:32:34.863Z",
+                "modified": "2018-06-18T17:32:34.865Z",
+                "partner_type": "",
+                "cso_type": null,
+                "name": "Partner 1",
+                "short_name": "",
+                "description": "",
+                "shared_with": null,
+                "street_address": null,
+                "city": null,
+                "postal_code": null,
+                "country": null,
+                "address": null,
+                "email": null,
+                "phone_number": null,
+                "vendor_number": null,
+                "alternate_id": null,
+                "alternate_name": null,
+                "rating": null,
+                "type_of_assessment": null,
+                "last_assessment_date": null,
+                "core_values_assessment_date": null,
+                "core_values_assessment": "",
+                "vision_synced": false,
+                "blocked": false,
+                "deleted_flag": false,
+                "manually_blocked": false,
+                "hidden": false,
+                "total_ct_cp": null,
+                "total_ct_cy": null,
+                "net_ct_cy": "2501.00",
+                "reported_cy": null,
+                "total_ct_ytd": null,
+                "hact_values": {
+                    "programmatic_visits": {
+                        "completed": {
+                            "total": 0
+                        }
+                    }
+                },
+                "basis_for_risk_rating": ""
+            }
+        },
+        "deps": []
     }
 }

--- a/src/requirements/test.txt
+++ b/src/requirements/test.txt
@@ -20,7 +20,6 @@ defusedxml==0.5.0
 diff-match-patch==20121119
 dj-database-url==0.5
 dj-static==0.0.6
-django-adminactions==1.5
 django-appconf==1.0.2
 django-celery-beat==1.1.1
 django-celery-email==2.0


### PR DESCRIPTION
Here's an update, adding tests for 2 API endpoints:
- `agreement-amendment-list`
- `partner-list-not-programmatic-visit`

Wanted to start small, to make sure I was doing this correctly. A few notes:
- This allows us to test GET endpoints, but not POST/DELETE, etc. Maybe that's obvious, but just wanted to be clear about it.
- I don't have a good sense of when to use ApiChecker vs ViewSetChecker