### PR TITLE
Update psycopg2 requirement to use binary package

### DIFF
--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -69,7 +69,8 @@ openapi-codec==1.3.2      # via django-rest-swagger
 openpyxl==2.5.0           # via tablib
 paste==2.0.3              # via pysaml2
 pillow==5.0.0             # via reportlab, xhtml2pdf
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
+psycopg2==2.7.4           # via django-tenant-schemas
 pycparser==2.18           # via cffi
 pycryptodomex==3.4.12     # via pysaml2
 pyjwt==1.5.3              # via djangorestframework-jwt

--- a/src/requirements/input/base.in
+++ b/src/requirements/input/base.in
@@ -39,7 +39,7 @@ GDAL==1.10.0
 gunicorn==19.7.1
 drfpasswordless==1.1.5
 pyyaml==3.12
-psycopg2==2.7.4
+psycopg2-binary==2.7.4
 raven==6.2.1
 tenant-schemas-celery==0.1.7
 

--- a/src/requirements/local.txt
+++ b/src/requirements/local.txt
@@ -54,6 +54,7 @@ djangorestframework-recursive==0.1.2
 djangorestframework-xml==1.3
 djangorestframework==3.6.4
 docutils==0.14            # via sphinx
+drf-api-checker==0.2.0
 drf-nested-routers==0.90.2
 drfpasswordless==1.1.5
 et-xmlfile==1.0.1
@@ -98,6 +99,7 @@ pillow==5.0.0
 pip-tools==2.0.2
 pluggy==0.6.0
 prompt-toolkit==1.0.15
+psycopg2-binary==2.7.4
 psycopg2==2.7.4
 ptyprocess==0.5.2
 py==1.5.3

--- a/src/requirements/production.txt
+++ b/src/requirements/production.txt
@@ -70,6 +70,7 @@ openapi-codec==1.3.2
 openpyxl==2.5.0
 paste==2.0.3
 pillow==5.0.0
+psycopg2-binary==2.7.4
 psycopg2==2.7.4
 pycparser==2.18
 pycryptodomex==3.4.12

--- a/src/requirements/test.txt
+++ b/src/requirements/test.txt
@@ -91,6 +91,7 @@ pickleshare==0.7.4        # via ipython
 pillow==5.0.0
 pluggy==0.6.0             # via tox
 prompt-toolkit==1.0.15    # via ipython
+psycopg2-binary==2.7.4
 psycopg2==2.7.4
 ptyprocess==0.5.2         # via pexpect
 py==1.5.3                 # via tox


### PR DESCRIPTION
[ch6519]

Still being required by some sub packages, but as those get updated the old requirement will be removed.