### PR TITLE
Update unicef-attachments to 0.2.4

### DIFF
--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -90,7 +90,7 @@ static3==0.7.0            # via dj-static
 tablib==0.12.1            # via django-import-export
 tenant-schemas-celery==0.1.7
 tornado==4.2.0            # via flower
-unicef-attachments==0.2.3
+unicef-attachments==0.2.4
 unicef-djangolib==0.5
 unicef-locations==1.3.1
 unicef_notification==0.2.0

--- a/src/requirements/input/base.in
+++ b/src/requirements/input/base.in
@@ -41,7 +41,7 @@ pyyaml==3.12
 psycopg2==2.7.5
 raven==6.2.1
 tenant-schemas-celery==0.1.7
-unicef-attachments==0.2.3
+unicef-attachments==0.2.4
 unicef-djangolib==0.5
 unicef-locations==1.3.1
 unicef_notification==0.2.0

--- a/src/requirements/test.txt
+++ b/src/requirements/test.txt
@@ -136,7 +136,7 @@ text-unidecode==1.2       # via faker
 tornado==4.2.0
 tox==3.0.0
 traitlets==4.3.2          # via ipython
-unicef-attachments==0.2.3
+unicef-attachments==0.2.4
 unicef-djangolib==0.5
 unicef-locations==1.3.1
 unicef_notification==0.2.0


### PR DESCRIPTION
[ch7200]

Fixes TypeError handling in attachment validation

See attachments library changes: https://github.com/unicef/unicef-attachments/commits/master