### PR TITLE
Fix AssertionErrror on incorrect request type in tpm visits subviews

### DIFF
--- a/src/etools/applications/tpm/tests/test_views.py
+++ b/src/etools/applications/tpm/tests/test_views.py
@@ -227,6 +227,36 @@ class TestTPMVisitViewSet(TestExportMixin, TPMTestCaseMixin, BaseTenantTestCase)
         visit = TPMVisitFactory(status='tpm_accepted')
         self._test_export(self.pme_user, 'tpm:visits-tpm-visit-letter', args=(visit.id,))
 
+    def test_implementing_partners_subview(self):
+        TPMVisitFactory(tpm_activities__count=1)
+
+        response = self.forced_auth_req(
+            'get',
+            reverse('tpm:visits-implementing-partners'),
+            user=self.unicef_user
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_sections_subview(self):
+        TPMVisitFactory(tpm_activities__count=1)
+
+        response = self.forced_auth_req(
+            'get',
+            reverse('tpm:visits-sections'),
+            user=self.unicef_user
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_cp_outputs_subview(self):
+        TPMVisitFactory(tpm_activities__count=1)
+
+        response = self.forced_auth_req(
+            'get',
+            reverse('tpm:visits-cp-outputs'),
+            user=self.unicef_user
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
 
 class TestTPMActionPointViewSet(TPMTestCaseMixin, BaseTenantTestCase):
     def test_action_point_added(self):

--- a/src/etools/applications/tpm/views.py
+++ b/src/etools/applications/tpm/views.py
@@ -351,17 +351,17 @@ class TPMVisitViewSet(
     @action(detail=False, methods=['get'], url_path='activities/implementing-partners')
     def implementing_partners(self, request, *args, **kwargs):
         visits = self.get_queryset()
-        return ImplementingPartnerView.as_view(visits=visits)(request, *args, **kwargs)
+        return ImplementingPartnerView.as_view(visits=visits)(request._request, *args, **kwargs)
 
     @action(detail=False, methods=['get'], url_path='activities/sections')
     def sections(self, request, *args, **kwargs):
         visits = self.get_queryset()
-        return VisitsSectionView.as_view(visits=visits)(request, *args, **kwargs)
+        return VisitsSectionView.as_view(visits=visits)(request._request, *args, **kwargs)
 
     @action(detail=False, methods=['get'], url_path='activities/cp-outputs')
     def cp_outputs(self, request, *args, **kwargs):
         visits = self.get_queryset()
-        return VisitsCPOutputView.as_view(visits=visits)(request, *args, **kwargs)
+        return VisitsCPOutputView.as_view(visits=visits)(request._request, *args, **kwargs)
 
     @action(detail=False, methods=['get'], url_path='export', renderer_classes=(TPMVisitCSVRenderer,))
     def visits_export(self, request, *args, **kwargs):


### PR DESCRIPTION
fixed
```
AssertionError at /api/tpm/visits/activities/sections/
The `request` argument must be an instance of `django.http.HttpRequest`, not `rest_framework.request.Request`.
```
inside tpm module