### PR TITLE
Ram indicators endpint

### DIFF
--- a/src/etools/applications/partners/serializers/interventions_v2.py
+++ b/src/etools/applications/partners/serializers/interventions_v2.py
@@ -33,6 +33,7 @@ from etools.applications.reports.serializers.v2 import (
     LowerResultCUSerializer,
     LowerResultSerializer,
     ReportingRequirementSerializer,
+    RAMIndicatorSerializer
 )
 
 
@@ -691,6 +692,19 @@ class InterventionReportingRequirementListSerializer(serializers.ModelSerializer
     class Meta:
         model = Intervention
         fields = ("reporting_requirements", )
+
+
+class InterventionRAMIndicatorsListSerializer(serializers.ModelSerializer):
+
+    ram_indicators = RAMIndicatorSerializer(
+        many=True,
+        read_only=True
+    )
+    cp_output_name = serializers.CharField(source="cp_output.output_name")
+
+    class Meta:
+        model = InterventionResultLink
+        fields = ("ram_indicators", "cp_output_name")
 
 
 class InterventionReportingRequirementCreateSerializer(serializers.ModelSerializer):

--- a/src/etools/applications/partners/urls_v2.py
+++ b/src/etools/applications/partners/urls_v2.py
@@ -18,13 +18,14 @@ from etools.applications.partners.views.interventions_v2 import (InterventionAme
                                                                  InterventionLocationListAPIView,
                                                                  InterventionLowerResultListCreateView,
                                                                  InterventionLowerResultUpdateView,
+                                                                 InterventionRamIndicatorsView,
                                                                  InterventionReportingPeriodDetailView,
                                                                  InterventionReportingPeriodListCreateView,
                                                                  InterventionReportingRequirementView,
                                                                  InterventionResultLinkListCreateView,
                                                                  InterventionResultLinkUpdateView,
                                                                  InterventionResultListAPIView,
-                                                                 InterventionSectionLocationLinkListAPIView, )
+                                                                 InterventionSectionLocationLinkListAPIView)
 from etools.applications.partners.views.partner_organization_v2 import (
     PartnerOrganizationAddView,
     PartnerOrganizationAssessmentDeleteView,
@@ -201,9 +202,12 @@ urlpatterns = (
         ),
         name='intervention-reporting-requirements'
     ),
+    url(
+        r'interventions/(?P<intervention_pk>\d+)/output_cp_indicators/(?P<cp_output_pk>\d+)/$',
+        view=InterventionRamIndicatorsView.as_view(http_method_names=['get']),
+        name="interventions-output-cp-indicators",
+    ),
 
-    # TODO: figure this out
-    # url(r'^partners/interventions/$', view=InterventionsView.as_view()),
     url(r'^dropdowns/static/$',
         view=PMPStaticDropdownsListAPIView.as_view(http_method_names=['get']),
         name='dropdown-static-list'),

--- a/src/etools/applications/partners/views/interventions_v2.py
+++ b/src/etools/applications/partners/views/interventions_v2.py
@@ -61,6 +61,7 @@ from etools.applications.partners.serializers.interventions_v2 import (
     InterventionListMapSerializer,
     InterventionListSerializer,
     InterventionLocationExportSerializer,
+    InterventionRAMIndicatorsListSerializer,
     InterventionReportingPeriodSerializer,
     InterventionReportingRequirementCreateSerializer,
     InterventionReportingRequirementListSerializer,
@@ -803,3 +804,19 @@ class InterventionReportingRequirementView(APIView):
                 self.serializer_list_class(self.get_data()).data
             )
         return Response(serializer.errors, status=status.HTTP_400_BAD_REQUEST)
+
+
+class InterventionRamIndicatorsView(APIView):
+
+    serializer_class = InterventionRAMIndicatorsListSerializer
+
+    def get(self, request, intervention_pk, cp_output_pk):
+
+        intervention = get_object_or_404(Intervention, pk=intervention_pk)
+
+        data = get_object_or_404(intervention.result_links.prefetch_related('cp_output__result_type', 'ram_indicators'),
+                                 cp_output__pk=cp_output_pk)
+
+        return Response(
+            self.serializer_class(data).data
+        )

--- a/src/etools/applications/reports/models.py
+++ b/src/etools/applications/reports/models.py
@@ -761,6 +761,13 @@ class Indicator(TimeStampedModel):
             u'Target: {}'.format(self.target) if self.target else u''
         )
 
+    @property
+    def light_repr(self):
+        return u'{}{}'.format(
+            u'' if self.active else u'[Inactive] ',
+            self.name
+        )
+
     def save(self, *args, **kwargs):
         # Prevent from saving empty strings as code because of the unique together constraint
         if not self.code:

--- a/src/etools/applications/reports/serializers/v2.py
+++ b/src/etools/applications/reports/serializers/v2.py
@@ -296,6 +296,17 @@ class IndicatorSerializer(serializers.ModelSerializer):
         fields = "__all__"
 
 
+class RAMIndicatorSerializer(serializers.ModelSerializer):
+    indicator_name = serializers.SerializerMethodField()
+
+    def get_indicator_name(self, obj):
+        return obj.light_repr
+
+    class Meta:
+        model = Indicator
+        fields = ("indicator_name",)
+
+
 class ReportingRequirementSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(required=False)
 


### PR DESCRIPTION
Fixes [CH 7155]

new edpoint `/api/v2/interventions/[intervention_id]/output_cp_indicators/[cp_output_id]/`

will return a 404 or indicators and output name as follows:
```
{
    "ram_indicators": [
        {
            "indicator_name": "[Inactive] Number and percentage of UNICEF-targeted children receiving psychosocial support"
        },
        {
            "indicator_name": "[Inactive] Number and percentage of UNICEF-targeted separated and unaccompanied children receiving alternative care services"
        },
        {
            "indicator_name": "[Inactive] Percentage and number of UNICEF-targeted children and women in humanitarian situations who experience GBV receiving multisectoral support services (health, psychosocial, livelihood/economic strengthening and justice)"
        }
    ],
    "cp_output_name": "CHILD PROTECTION IN EMERGENCIES"
}
```