### PR TITLE
Add management command to update attachment seq

### DIFF
--- a/src/etools/applications/attachments/management/commands/update_attachment_seq.py
+++ b/src/etools/applications/attachments/management/commands/update_attachment_seq.py
@@ -1,0 +1,25 @@
+from django.core.management.base import BaseCommand
+from django.db import connection
+from django.db.models import Max
+
+from etools.applications.utils.common.utils import run_on_all_tenants
+
+from unicef_attachments.models import Attachment
+
+
+class Command(BaseCommand):
+    """Update seq value for attachment model"""
+
+    def run(self):
+        # get max id for attachments
+        # update seq value to match this
+        row = Attachment.objects.aggregate(max_id=Max("id"))
+        cursor = connection.cursor()
+        cursor.execute(
+            "SELECT setval('unicef_attachments_attachment_id_seq', {}, TRUE)".format(
+                row["max_id"]
+            )
+        )
+
+    def handle(self, *args, **options):
+        run_on_all_tenants(self.run)


### PR DESCRIPTION
[ch7624]

The issue is that the sequence is out of balance with the records in the attachment table. This was due to the records being copied/transferred from old attachment table with `id` value set in order to maintain relationship to the various objects.

This PR provides a management command that resets the sequence values. Run it with;

`python manage.py update_attachment_seq`

You can also copy parts of the management command (`src/etools/applications/attachments/management/commands/update_attachment_seq.py`) and run it in a django shell in another environment if needed.