### PR TITLE
Hide TPM Visits from partners if they were cancelled from draft

### DIFF
--- a/src/etools/applications/tpm/tests/test_views.py
+++ b/src/etools/applications/tpm/tests/test_views.py
@@ -42,8 +42,9 @@ class TestTPMVisitViewSet(TestExportMixin, TPMTestCaseMixin, BaseTenantTestCase)
 
     def test_tpm_list_view(self):
         TPMVisitFactory()
+        TPMVisitFactory(status='cancelled', date_of_assigned=None)
 
-        # drafts shouldn't be available for tpm
+        # drafts shouldn't be available for tpm, including cancelled from draft
         self._test_list_view(self.tpm_user, [])
 
         visit = TPMVisitFactory(status='assigned',

--- a/src/etools/applications/tpm/views.py
+++ b/src/etools/applications/tpm/views.py
@@ -1,4 +1,5 @@
 from django.contrib.contenttypes.models import ContentType
+from django.db.models import Q
 from django.http import Http404
 from django.utils import timezone
 from django.utils.translation import ugettext_lazy as _
@@ -335,7 +336,10 @@ class TPMVisitViewSet(
                 hasattr(self.request.user, 'tpmpartners_tpmpartnerstaffmember'):
             queryset = queryset.filter(
                 tpm_partner=self.request.user.tpmpartners_tpmpartnerstaffmember.tpm_partner
-            ).exclude(status=TPMVisit.STATUSES.draft)
+            ).exclude(
+                Q(status=TPMVisit.STATUSES.draft) |
+                Q(status=TPMVisit.STATUSES.cancelled, date_of_assigned__isnull=True)  # cancelled draft
+            )
         else:
             queryset = queryset.none()
 


### PR DESCRIPTION
visits should be visible for them only after assignment