### PR TITLE
Add vendor number to partner dashboard

### DIFF
--- a/src/etools/applications/partners/serializers/partner_organization_v2.py
+++ b/src/etools/applications/partners/serializers/partner_organization_v2.py
@@ -314,6 +314,7 @@ class PartnerOrganizationDashboardSerializer(serializers.ModelSerializer):
             'total_ct_ytd',
             'outstanding_dct_amount_6_to_9_months_usd',
             'outstanding_dct_amount_more_than_9_months_usd',
+            'vendor_number',
         )
 
 

--- a/src/etools/applications/partners/tests/test_views.py
+++ b/src/etools/applications/partners/tests/test_views.py
@@ -2306,3 +2306,4 @@ class TestPartnerOrganizationDashboardAPIView(BaseTenantTestCase):
         self.assertEquals(self.record['days_last_pv'], 200)
         self.assertTrue(self.record['alert_no_recent_pv'])
         self.assertFalse(self.record['alert_no_pv'])
+        self.assertTrue(self.record['vendor_number'])


### PR DESCRIPTION
[ch5112]

Looks like you are also able to search on `vendor_number` with `vendor_number__icontains`