### PR TITLE
allow proper packaging

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,12 +31,13 @@ def get_requirements(env):
                 continue
             line = line[:-1]
             if line.startswith('-e git+'):
-                url = line.replace('-e ', '')
+                url = line.replace('-e git+', '')
                 groups = re.match(".*@(?P<version>.*)#egg=(?P<name>.*)", line).groupdict()
                 version = groups['version'].replace('v', '')
                 egg = line.partition('egg=')[2]
-                ret.append(f"{egg}=={version}")
-                dependency_links.add(f"{url}-{version}")
+                # ret.append(f"{egg}=={version}")
+                # dependency_links.add(f"{url}-{version}")
+                ret.append(f"{url}-{version}")
             else:
                 dep = line.partition('#')[0]
                 ret.append(dep.strip())
@@ -45,7 +46,10 @@ def get_requirements(env):
 
 install_requires = get_requirements('base')
 test_requires = get_requirements('test')
-
+# TODO: remove me
+# print(111, "setup.py:49", dependency_links)
+# print(111, "setup.py:49", install_requires)
+print(111, "setup.py:49", test_requires)
 setup(
     name=NAME,
     version=VERSION,

--- a/src/etools/__init__.py
+++ b/src/etools/__init__.py
@@ -1,2 +1,2 @@
-VERSION = __version__ = '5.0a0'
+VERSION = __version__ = '6.4a'
 NAME = 'eTools'

--- a/src/requirements/base.txt
+++ b/src/requirements/base.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
+unicef-djangosaml2==0.17.2
 amqp==2.2.2               # via kombu
 asn1crypto==0.24.0        # via cryptography
 azure-common==1.1.8       # via azure-storage

--- a/src/requirements/input/base.in
+++ b/src/requirements/input/base.in
@@ -48,4 +48,4 @@ unicef_notification==0.2.0
 unicef_restlib==0.3.4
 unicef_snapshot==0.2.1
 
--e git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
+unicef-djangosaml2==0.17.2

--- a/src/requirements/test.txt
+++ b/src/requirements/test.txt
@@ -1,4 +1,4 @@
--e git+https://github.com/unicef/djangosaml2.git@v0.16.11.2#egg=djangosaml2
+unicef-djangosaml2==0.17.2
 alabaster==0.7.11         # via sphinx
 amqp==2.2.2
 asn1crypto==0.24.0


### PR DESCRIPTION
fixes setup.py, removes dependency from git+djangosaml2 and uses unicef-djangosaml2 properly available on pypi

This PR allow etools to be used as dependency, enabling datamart upgrades.