### PR TITLE
TPM attachment updates

### DIFF
--- a/src/etools/applications/attachments/tests/factories.py
+++ b/src/etools/applications/attachments/tests/factories.py
@@ -1,7 +1,7 @@
 import factory.django
 from factory import fuzzy
 
-from unicef_attachments.models import Attachment, FileType
+from unicef_attachments.models import Attachment, AttachmentLink, FileType
 
 
 class AttachmentFileTypeFactory(factory.django.DjangoModelFactory):
@@ -19,3 +19,10 @@ class AttachmentFactory(factory.django.DjangoModelFactory):
 
     class Meta:
         model = Attachment
+
+
+class AttachmentLinkFactory(factory.django.DjangoModelFactory):
+    attachment = factory.SubFactory(AttachmentFactory)
+
+    class Meta:
+        model = AttachmentLink

--- a/src/etools/applications/tpm/serializers/attachments.py
+++ b/src/etools/applications/tpm/serializers/attachments.py
@@ -9,9 +9,23 @@ from unicef_attachments.serializers import AttachmentLinkSerializer, BaseAttachm
 class TPMPartnerAttachmentsSerializer(BaseAttachmentSerializer):
     file_type = FileTypeModelChoiceField(queryset=FileType.objects.filter(
         code="tpm_partner"), label=_('Document Type'))
+    source = serializers.SerializerMethodField()
 
     class Meta(BaseAttachmentSerializer.Meta):
-        pass
+        fields = [
+            'id',
+            'file_type',
+            'file',
+            'hyperlink',
+            'created',
+            'modified',
+            'uploaded_by',
+            'filename',
+            'source',
+        ]
+
+    def get_source(self, obj):
+        return "Third Party Monitoring"
 
 
 class ActivityAttachmentsSerializer(BaseAttachmentSerializer):
@@ -60,8 +74,27 @@ class TPMVisitAttachmentsSerializer(BaseAttachmentSerializer):
         return super().create(validated_data)
 
 
+
+class TPMAttachmentLinkSerializer(AttachmentLinkSerializer):
+    source = serializers.SerializerMethodField()
+
+    class Meta(AttachmentLinkSerializer.Meta):
+        fields = (
+            "id",
+            "attachment",
+            "filename",
+            "url",
+            "file_type",
+            "created",
+            "source",
+        )
+
+    def get_source(self, obj):
+        return "Third Party Monitoring"
+
+
 class TPMActivityAttachmentLinkSerializer(serializers.Serializer):
-    attachments = AttachmentLinkSerializer(many=True, allow_empty=False)
+    attachments = TPMAttachmentLinkSerializer(many=True, allow_empty=False)
 
     def create(self, validated_data):
         links = []

--- a/src/etools/applications/tpm/serializers/attachments.py
+++ b/src/etools/applications/tpm/serializers/attachments.py
@@ -76,6 +76,7 @@ class TPMVisitAttachmentsSerializer(BaseAttachmentSerializer):
 
 class TPMAttachmentLinkSerializer(AttachmentLinkSerializer):
     source = serializers.SerializerMethodField()
+    activity_id = serializers.IntegerField(source="object_id", read_only=True)
 
     class Meta(AttachmentLinkSerializer.Meta):
         fields = (
@@ -86,6 +87,7 @@ class TPMAttachmentLinkSerializer(AttachmentLinkSerializer):
             "file_type",
             "created",
             "source",
+            "activity_id",
         )
 
     def get_source(self, obj):
@@ -104,3 +106,10 @@ class TPMActivityAttachmentLinkSerializer(serializers.Serializer):
                 object_id=self.context["object_id"],
             ))
         return {"attachments": links}
+
+
+class TPMVisitAttachmentLinkSerializer(serializers.Serializer):
+    activity_attachments = TPMAttachmentLinkSerializer(
+        many=True,
+        read_only=True,
+    )

--- a/src/etools/applications/tpm/serializers/attachments.py
+++ b/src/etools/applications/tpm/serializers/attachments.py
@@ -74,7 +74,6 @@ class TPMVisitAttachmentsSerializer(BaseAttachmentSerializer):
         return super().create(validated_data)
 
 
-
 class TPMAttachmentLinkSerializer(AttachmentLinkSerializer):
     source = serializers.SerializerMethodField()
 

--- a/src/etools/applications/tpm/tests/test_views.py
+++ b/src/etools/applications/tpm/tests/test_views.py
@@ -621,7 +621,7 @@ class TestTPMPartnerViewSet(TestExportMixin, TPMTestCaseMixin, BaseTenantTestCas
 
 
 class TestPartnerAttachmentsView(TPMTestCaseMixin, BaseTenantTestCase):
-    def test_list(self):
+    def test_list_pme_user(self):
         partner = TPMPartnerFactory()
         attachments_num = partner.attachments.count()
 
@@ -631,6 +631,19 @@ class TestPartnerAttachmentsView(TPMTestCaseMixin, BaseTenantTestCase):
             'get',
             reverse('tpm:partner-attachments-list', args=[partner.id]),
             user=self.pme_user
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data['results']), attachments_num + 1)
+
+    def test_list_tpm_user(self):
+        attachments_num = self.tpm_partner.attachments.count()
+
+        AttachmentFactory(content_object=self.tpm_partner)
+
+        response = self.forced_auth_req(
+            'get',
+            reverse('tpm:partner-attachments-list', args=[self.tpm_partner.pk]),
+            user=self.tpm_user
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(len(response.data['results']), attachments_num + 1)

--- a/src/etools/applications/tpm/urls.py
+++ b/src/etools/applications/tpm/urls.py
@@ -12,6 +12,7 @@ from etools.applications.tpm.views import (
     TPMPartnerViewSet,
     TPMStaffMembersViewSet,
     TPMVisitViewSet,
+    VisitAttachmentLinksView,
     VisitAttachmentsViewSet,
     VisitReportAttachmentsViewSet,
 )
@@ -53,5 +54,10 @@ urlpatterns = [
         r'^visits/activities/(?P<object_pk>\d+)/links',
         view=ActivityAttachmentLinksView.as_view(),
         name='activity-links'
-    )
+    ),
+    url(
+        r'^visits/(?P<object_pk>\d+)/links',
+        view=VisitAttachmentLinksView.as_view(),
+        name='visit-links'
+    ),
 ]


### PR DESCRIPTION
Added new endpoint `api/v2/tpm/visits/<visit-id>/links` that provides a list of attachment links for all the activities associated with the visit. 

Also updated the results to include `source` and `activity_id`

These changes were made to help Marko on the frontend