### PR TITLE
Ensure we pass a list of recipients to send_notification_with_template

### DIFF
--- a/src/etools/applications/partners/tests/test_api_agreements.py
+++ b/src/etools/applications/partners/tests/test_api_agreements.py
@@ -1,5 +1,6 @@
 import datetime
 import json
+import mock
 
 from django.test import SimpleTestCase
 from django.urls import reverse
@@ -441,3 +442,24 @@ class TestAgreementsAPI(BaseTenantTestCase):
         )
         agreement_updated = Agreement.objects.get(pk=agreement.pk)
         self.assertEqual(agreement_updated.attachment.last(), attachment_new)
+
+    def test_patch_agreement_suspended(self):
+        agreement = AgreementFactory(
+            partner=self.partner1,
+        )
+        assert agreement.status != Agreement.SUSPENDED
+
+        data = {
+            "status": Agreement.SUSPENDED
+        }
+        mock_send = mock.Mock()
+        send_path = "etools.applications.partners.utils.send_notification_with_template"
+        with mock.patch(send_path, mock_send):
+            status_code, response = self.run_request(
+                agreement.pk,
+                data,
+                method="patch",
+            )
+
+        self.assertEqual(status_code, status.HTTP_200_OK)
+        mock_send.assert_called()

--- a/src/etools/applications/partners/utils.py
+++ b/src/etools/applications/partners/utils.py
@@ -402,7 +402,6 @@ def send_agreement_suspended_notification(agreement, user):
         pd_list.append((sections, intervention.reference_number, url))
 
     send_notification_with_template(
-        sender=agreement,
         recipients=[user.email],  # person that initiated this update
         template_name="partners/agreement/suspended",
         context={

--- a/src/etools/applications/partners/utils.py
+++ b/src/etools/applications/partners/utils.py
@@ -403,7 +403,7 @@ def send_agreement_suspended_notification(agreement, user):
 
     send_notification_with_template(
         sender=agreement,
-        recipients=user.email,  # person that initiated this update
+        recipients=[user.email],  # person that initiated this update
         template_name="partners/agreement/suspended",
         context={
             "vendor_number": agreement.reference_number,


### PR DESCRIPTION
[ch7539]

Need to pass a list of recipients to send_notification_with_template

Should update the library to validate/convert this `recipients` param to list if a str