### PR TITLE
Use correct file type for TPMAttachmentLinks

### DIFF
--- a/src/etools/applications/tpm/serializers/attachments.py
+++ b/src/etools/applications/tpm/serializers/attachments.py
@@ -4,6 +4,7 @@ from rest_framework import serializers
 from unicef_attachments.fields import FileTypeModelChoiceField
 from unicef_attachments.models import AttachmentLink, FileType
 from unicef_attachments.serializers import AttachmentLinkSerializer, BaseAttachmentSerializer
+from etools.applications.attachments.utils import get_file_type
 
 
 class TPMPartnerAttachmentsSerializer(BaseAttachmentSerializer):
@@ -77,6 +78,7 @@ class TPMVisitAttachmentsSerializer(BaseAttachmentSerializer):
 class TPMAttachmentLinkSerializer(AttachmentLinkSerializer):
     source = serializers.SerializerMethodField()
     activity_id = serializers.IntegerField(source="object_id", read_only=True)
+    file_type = serializers.SerializerMethodField()
 
     class Meta(AttachmentLinkSerializer.Meta):
         fields = (
@@ -92,6 +94,9 @@ class TPMAttachmentLinkSerializer(AttachmentLinkSerializer):
 
     def get_source(self, obj):
         return "Third Party Monitoring"
+
+    def get_file_type(self, obj):
+        return get_file_type(obj.attachment)
 
 
 class TPMActivityAttachmentLinkSerializer(serializers.Serializer):

--- a/src/etools/applications/tpm/tests/test_views.py
+++ b/src/etools/applications/tpm/tests/test_views.py
@@ -17,6 +17,7 @@ from etools.applications.attachments.tests.factories import (
 )
 from etools.applications.EquiTrack.tests.cases import BaseTenantTestCase
 from etools.applications.partners.models import PartnerType
+from etools.applications.partners.tests.factories import InterventionAttachmentFactory
 from etools.applications.reports.tests.factories import SectionFactory
 from etools.applications.tpm.models import ThirdPartyMonitor, TPMVisit
 from etools.applications.tpm.tests.base import TPMTestCaseMixin
@@ -866,8 +867,8 @@ class TestVisitAttachmentLinkView(TPMTestCaseMixin, BaseTenantTestCase):
             tpm_activities__count=1
         )
         cls.activity = cls.visit.tpm_activities.first()
-        partner = TPMPartnerFactory()
-        cls.attachment = AttachmentFactory(content_object=partner)
+        cls.intervention_attachment = InterventionAttachmentFactory()
+        cls.attachment = AttachmentFactory(content_object=cls.intervention_attachment)
         cls.attachment_link = AttachmentLinkFactory(
             attachment=cls.attachment,
             content_object=cls.activity
@@ -883,3 +884,4 @@ class TestVisitAttachmentLinkView(TPMTestCaseMixin, BaseTenantTestCase):
         data = response.data
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["id"], self.attachment_link.pk)
+        self.assertEqual(data[0]["file_type"], self.intervention_attachment.type.name)


### PR DESCRIPTION
[ch8861]

`InterventionAttachments` have a `type` field that needs to be used for `file_type`