### PR TITLE
Update Dockerfile-dev to set REQUIREMENTS_FILE env var

### DIFF
--- a/Dockerfile-dev
+++ b/Dockerfile-dev
@@ -40,7 +40,7 @@ RUN pip install --upgrade \
 # http://gis.stackexchange.com/a/74060
 ENV CPLUS_INCLUDE_PATH /usr/include/gdal
 ENV C_INCLUDE_PATH /usr/include/gdal
-ARG REQUIREMENTS_FILE=test.txt
+ENV REQUIREMENTS_FILE=test.txt
 
 ADD src/requirements/*.txt /pip/
 ADD src/requirements/$REQUIREMENTS_FILE /pip/app_requirements.txt


### PR DESCRIPTION
Locally I was having issues re-building backend container, as the REQUIREMENTS_FILE env was not being set correctly.