### PR TITLE
Update AppliedIndicatorSerializer test to be more robust

### DIFF
--- a/src/etools/applications/reports/tests/test_serializers.py
+++ b/src/etools/applications/reports/tests/test_serializers.py
@@ -104,6 +104,7 @@ class TestAppliedIndicatorSerializer(BaseTenantTestCase):
         )
         self.applied_indicator = AppliedIndicatorFactory(
             lower_result=self.lower_result,
+            target={"d": 3, "v": 4},
         )
         self.intervention.flat_locations.add(self.location)
         self.intervention.sections.add(self.section)


### PR DESCRIPTION
Set value of target specifically, remove chance of values matching and causing test to fail

`AppliedIndicatorFactory` bt default sets `target` `d` value to values between `0 - 5` and the test was using value of `1`, so there was a 20% chance that test would fail.

Specifically setting the target value, so test is more robust now.