### PR TITLE
Fix factories to handle running tests on last day of the year

### DIFF
--- a/src/etools/applications/t2f/tests/factories.py
+++ b/src/etools/applications/t2f/tests/factories.py
@@ -1,3 +1,4 @@
+import datetime
 
 from django.utils import timezone
 
@@ -59,8 +60,14 @@ class TravelActivityFactory(factory.django.DjangoModelFactory):
 class ItineraryItemFactory(factory.DjangoModelFactory):
     origin = fuzzy.FuzzyText(length=32)
     destination = fuzzy.FuzzyText(length=32)
-    departure_date = fuzzy.FuzzyDateTime(start_dt=_FUZZY_START_DATE, end_dt=timezone.now())
-    arrival_date = fuzzy.FuzzyDateTime(start_dt=timezone.now(), end_dt=_FUZZY_END_DATE)
+    departure_date = fuzzy.FuzzyDateTime(
+        start_dt=_FUZZY_START_DATE,
+        end_dt=timezone.now() - datetime.timedelta(days=7),
+    )
+    arrival_date = fuzzy.FuzzyDateTime(
+        start_dt=timezone.now() - datetime.timedelta(days=5),
+        end_dt=_FUZZY_END_DATE,
+    )
     dsa_region = factory.SubFactory(PublicsDSARegionFactory)
     overnight_travel = False
     mode_of_travel = models.ModeOfTravel.BOAT
@@ -119,8 +126,14 @@ class TravelFactory(factory.DjangoModelFactory):
     supervisor = factory.SubFactory(UserFactory)
     office = factory.SubFactory(OfficeFactory)
     section = factory.SubFactory(SectionFactory)
-    start_date = fuzzy.FuzzyDateTime(start_dt=_FUZZY_START_DATE, end_dt=timezone.now())
-    end_date = fuzzy.FuzzyDateTime(start_dt=timezone.now(), end_dt=_FUZZY_END_DATE)
+    start_date = fuzzy.FuzzyDateTime(
+        start_dt=_FUZZY_START_DATE,
+        end_dt=timezone.now() - datetime.timedelta(days=7),
+    )
+    end_date = fuzzy.FuzzyDateTime(
+        start_dt=timezone.now() - datetime.timedelta(days=5),
+        end_dt=_FUZZY_END_DATE,
+    )
     purpose = factory.Sequence(lambda n: 'Purpose #{}'.format(n))
     international_travel = False
     ta_required = True

--- a/src/etools/applications/t2f/tests/factories.py
+++ b/src/etools/applications/t2f/tests/factories.py
@@ -22,6 +22,12 @@ from etools.applications.users.tests.factories import OfficeFactory, UserFactory
 
 _FUZZY_START_DATE = timezone.datetime(timezone.now().year, 1, 1, tzinfo=timezone.now().tzinfo)
 _FUZZY_END_DATE = timezone.datetime(timezone.now().year, 12, 31, tzinfo=timezone.now().tzinfo)
+_FUZZY_NOW_DATE = timezone.datetime(
+    timezone.now().year,
+    timezone.now().month,
+    timezone.now().day,
+    tzinfo=timezone.now().tzinfo
+)
 
 
 class FuzzyTravelType(factory.fuzzy.BaseFuzzyAttribute):
@@ -62,10 +68,10 @@ class ItineraryItemFactory(factory.DjangoModelFactory):
     destination = fuzzy.FuzzyText(length=32)
     departure_date = fuzzy.FuzzyDateTime(
         start_dt=_FUZZY_START_DATE,
-        end_dt=timezone.now() - datetime.timedelta(days=7),
+        end_dt=_FUZZY_NOW_DATE,
     )
     arrival_date = fuzzy.FuzzyDateTime(
-        start_dt=timezone.now() - datetime.timedelta(days=5),
+        start_dt=_FUZZY_NOW_DATE,
         end_dt=_FUZZY_END_DATE,
     )
     dsa_region = factory.SubFactory(PublicsDSARegionFactory)
@@ -128,10 +134,10 @@ class TravelFactory(factory.DjangoModelFactory):
     section = factory.SubFactory(SectionFactory)
     start_date = fuzzy.FuzzyDateTime(
         start_dt=_FUZZY_START_DATE,
-        end_dt=timezone.now() - datetime.timedelta(days=7),
+        end_dt=_FUZZY_NOW_DATE,
     )
     end_date = fuzzy.FuzzyDateTime(
-        start_dt=timezone.now() - datetime.timedelta(days=5),
+        start_dt=_FUZZY_NOW_DATE,
         end_dt=_FUZZY_END_DATE,
     )
     purpose = factory.Sequence(lambda n: 'Purpose #{}'.format(n))

--- a/src/etools/applications/t2f/tests/factories.py
+++ b/src/etools/applications/t2f/tests/factories.py
@@ -1,5 +1,3 @@
-import datetime
-
 from django.utils import timezone
 
 import factory


### PR DESCRIPTION
When running tests on the last day of the year, there is an issue with the fuzzy dates where start value > end value.