### PR TITLE
Travel Activity is required for T2FActionPoint models

### DIFF
--- a/src/etools/applications/audit/admin.py
+++ b/src/etools/applications/audit/admin.py
@@ -1,12 +1,23 @@
-
 from django.contrib import admin
 
 from ordered_model.admin import OrderedModelAdmin
 
 from etools.applications.action_points.admin import ActionPointAdmin
-from etools.applications.audit.models import (Audit, Engagement, FinancialFinding, Finding, MicroAssessment,
-                                              Risk, RiskBluePrint, RiskCategory, SpecialAuditRecommendation,
-                                              SpecificProcedure, SpotCheck, EngagementActionPoint)
+from etools.applications.audit.forms import EngagementActionPointAdminForm
+from etools.applications.audit.models import (
+    Audit,
+    Engagement,
+    EngagementActionPoint,
+    FinancialFinding,
+    Finding,
+    MicroAssessment,
+    Risk,
+    RiskBluePrint,
+    RiskCategory,
+    SpecialAuditRecommendation,
+    SpecificProcedure,
+    SpotCheck,
+)
 
 
 @admin.register(Engagement)
@@ -94,4 +105,5 @@ class SpecialAuditRecommendationAdmin(admin.ModelAdmin):
 
 @admin.register(EngagementActionPoint)
 class EngagementActionPointAdmin(ActionPointAdmin):
+    form = EngagementActionPointAdminForm
     list_display = ('engagement', ) + ActionPointAdmin.list_display

--- a/src/etools/applications/audit/forms.py
+++ b/src/etools/applications/audit/forms.py
@@ -1,0 +1,11 @@
+from django import forms
+from etools.applications.audit.models import EngagementActionPoint
+
+
+class EngagementActionPointAdminForm(forms.ModelForm):
+    model = EngagementActionPoint
+    fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["engagement"].required = True

--- a/src/etools/applications/t2f/admin.py
+++ b/src/etools/applications/t2f/admin.py
@@ -4,6 +4,7 @@ from etools.applications.action_points.admin import ActionPointAdmin
 from etools.applications.publics.admin import AdminListMixin
 from etools.applications.t2f import models
 from etools.applications.t2f.models import T2FActionPoint
+from etools.applications.t2f.forms import T2FActionPointAdminForm
 
 
 @admin.register(models.Travel)
@@ -83,4 +84,4 @@ class TravelAttachmentAdmin(AdminListMixin, admin.ModelAdmin):
 
 @admin.register(T2FActionPoint)
 class T2FActionPointAdmin(ActionPointAdmin):
-    pass
+    form = T2FActionPointAdminForm

--- a/src/etools/applications/t2f/forms.py
+++ b/src/etools/applications/t2f/forms.py
@@ -1,0 +1,11 @@
+from django import forms
+from etools.applications.t2f.models import T2FActionPoint
+
+
+class T2FActionPointAdminForm(forms.ModelForm):
+    model = T2FActionPoint
+    fields = "__all__"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.fields["travel_activity"].required = True


### PR DESCRIPTION
[ch9782]

If `travel_activity` is not set record is not considered a T2FActionPoint, rather just a ActionPoint.
Hence the snapshot fails to find the record, when creating the delta.