### PR TITLE
Ensure code is set for Intervention Attachment formset

### DIFF
--- a/src/etools/applications/partners/admin.py
+++ b/src/etools/applications/partners/admin.py
@@ -193,6 +193,12 @@ class InterventionAttachmentsInline(admin.TabularInline):
         'attachment',
     )
     extra = 0
+    code = 'partners_intervention_attachment'
+
+    def get_formset(self, request, obj=None, **kwargs):
+        formset = super().get_formset(request, obj, **kwargs)
+        formset.code = self.code
+        return formset
 
 
 class InterventionResultsLinkAdmin(admin.ModelAdmin):


### PR DESCRIPTION
[ch9315]

Fix issue where `code` was not being set in formset
See https://sentry.io/share/issue/16732112047f49d993d80c6b152e6fcf/