### PR TITLE
Remove attachment_file from list display in InterventionAttachment admin

### DIFF
--- a/src/etools/applications/partners/admin.py
+++ b/src/etools/applications/partners/admin.py
@@ -174,7 +174,6 @@ class InterventionAttachmentAdmin(AttachmentInlineAdminMixin, admin.ModelAdmin):
     model = InterventionAttachment
     list_display = (
         'intervention',
-        'attachment_file',
         'type',
     )
     list_filter = (


### PR DESCRIPTION
This was causing an error when attempting to view the admin page