### PR TITLE
Validate overlapping dates in Approved, and Completed status as well

### DIFF
--- a/src/etools/applications/t2f/serializers/travel.py
+++ b/src/etools/applications/t2f/serializers/travel.py
@@ -1,3 +1,4 @@
+import datetime
 import operator
 from itertools import chain
 
@@ -218,7 +219,17 @@ class TravelDetailsSerializer(PermissionBasedModelSerializer):
                 # or end date between the range of the start and end date of the current trip
                 travel_q = Q(traveler=traveler)
                 travel_q &= ~Q(status__in=[Travel.PLANNED, Travel.CANCELLED])
-                travel_q &= Q(start_date__range=(start_date, end_date)) | Q(end_date__range=(start_date, end_date))
+                travel_q &= Q(
+                    start_date__date__range=(
+                        start_date.date(),
+                        end_date.date() - datetime.timedelta(days=1),
+                    )
+                ) | Q(
+                    end_date__date__range=(
+                        start_date.date() + datetime.timedelta(days=1),
+                        end_date.date(),
+                    )
+                )
 
                 # In case of first save, no id present
                 if self.instance:

--- a/src/etools/applications/t2f/serializers/travel.py
+++ b/src/etools/applications/t2f/serializers/travel.py
@@ -205,7 +205,7 @@ class TravelDetailsSerializer(PermissionBasedModelSerializer):
         if 'mode_of_travel' in attrs and attrs['mode_of_travel'] is None:
             attrs['mode_of_travel'] = []
 
-        if self.transition_name == Travel.SUBMIT_FOR_APPROVAL:
+        if self.transition_name in [Travel.SUBMIT_FOR_APPROVAL, Travel.APPROVED, Travel.COMPLETED]:
             traveler = attrs.get('traveler', None)
             if not traveler and self.instance:
                 traveler = self.instance.traveler

--- a/src/etools/applications/t2f/tests/test_overlapping_trips.py
+++ b/src/etools/applications/t2f/tests/test_overlapping_trips.py
@@ -1,7 +1,6 @@
-
+import datetime
 import json
 import logging
-from datetime import datetime
 
 from django.urls import reverse
 
@@ -40,8 +39,8 @@ class OverlappingTravelsTest(BaseTenantTestCase):
         cls.travel = TravelFactory(reference_number=make_travel_reference_number(),
                                    traveler=cls.traveler,
                                    supervisor=cls.unicef_staff,
-                                   start_date=datetime(2017, 4, 4, 12, 00, tzinfo=UTC),
-                                   end_date=datetime(2017, 4, 14, 16, 00, tzinfo=UTC))
+                                   start_date=datetime.datetime(2017, 4, 4, 12, 00, tzinfo=UTC),
+                                   end_date=datetime.datetime(2017, 4, 14, 16, 00, tzinfo=UTC))
         ItineraryItemFactory(travel=cls.travel)
         ItineraryItemFactory(travel=cls.travel)
         cls.travel.submit_for_approval()
@@ -86,7 +85,7 @@ class OverlappingTravelsTest(BaseTenantTestCase):
 
         travel_id = response_json['id']
 
-        with freeze_time(datetime(2017, 4, 14, 16, 00, tzinfo=UTC)):
+        with freeze_time(datetime.datetime(2017, 4, 14, 16, 00, tzinfo=UTC)):
             response = self.forced_auth_req('post', reverse('t2f:travels:details:state_change',
                                                             kwargs={'travel_pk': travel_id,
                                                                     'transition_name': Travel.SUBMIT_FOR_APPROVAL}),
@@ -98,7 +97,7 @@ class OverlappingTravelsTest(BaseTenantTestCase):
 
     def test_almost_overlapping_trips(self):
         currency = PublicsCurrencyFactory()
-        dsa_rate = PublicsDSARateFactory(effective_from_date=datetime(2017, 4, 10, 16, 00, tzinfo=UTC))
+        dsa_rate = PublicsDSARateFactory(effective_from_date=datetime.datetime(2017, 4, 10, 16, 00, tzinfo=UTC))
         dsa_region = dsa_rate.region
 
         data = {'itinerary': [{'origin': 'Berlin',
@@ -133,7 +132,7 @@ class OverlappingTravelsTest(BaseTenantTestCase):
                                         data=data, user=self.traveler)
         response_json = json.loads(response.rendered_content)
 
-        with freeze_time(datetime(2017, 4, 14, 16, 00, tzinfo=UTC)):
+        with freeze_time(datetime.datetime(2017, 4, 14, 16, 00, tzinfo=UTC)):
             response = self.forced_auth_req('post', reverse('t2f:travels:details:state_change',
                                                             kwargs={'travel_pk': response_json['id'],
                                                                     'transition_name': Travel.SUBMIT_FOR_APPROVAL}),
@@ -178,7 +177,7 @@ class OverlappingTravelsTest(BaseTenantTestCase):
                                         data=data, user=self.traveler)
         response_json = json.loads(response.rendered_content)
 
-        with freeze_time(datetime(2017, 4, 14, 16, 00, tzinfo=UTC)):
+        with freeze_time(datetime.datetime(2017, 4, 14, 16, 00, tzinfo=UTC)):
             response = self.forced_auth_req('post', reverse('t2f:travels:details:state_change',
                                                             kwargs={'travel_pk': response_json['id'],
                                                                     'transition_name': Travel.SUBMIT_FOR_APPROVAL}),
@@ -220,17 +219,18 @@ class OverlappingTravelsTest(BaseTenantTestCase):
                                                                  'transition_name': Travel.SUBMIT_FOR_APPROVAL}),
                                         data=response_json, user=self.traveler)
         response_json = json.loads(response.rendered_content)
+        assert response.status_code == 400
         self.assertEqual(response_json,
                          {'non_field_errors': ['You have an existing trip with overlapping dates. '
                                                'Please adjust your trip accordingly.']})
 
     def test_daylight_saving(self):
         budapest_tz = pytz.timezone('Europe/Budapest')
-        self.travel.end_date = budapest_tz.localize(datetime(2017, 10, 29, 2, 0), is_dst=True)
+        self.travel.end_date = budapest_tz.localize(datetime.datetime(2017, 10, 29, 2, 0), is_dst=True)
         self.travel.save()
 
         # Same date as the previous, but it's already after daylight saving
-        start_date = budapest_tz.localize(datetime(2017, 10, 29, 2, 0), is_dst=False).isoformat()
+        start_date = budapest_tz.localize(datetime.datetime(2017, 10, 29, 2, 0), is_dst=False).isoformat()
 
         currency = PublicsCurrencyFactory()
         dsa_region = PublicsDSARegionFactory()
@@ -266,3 +266,119 @@ class OverlappingTravelsTest(BaseTenantTestCase):
         response = self.forced_auth_req('post', reverse('t2f:travels:list:index'),
                                         data=data, user=self.traveler)
         self.assertEqual(response.status_code, 201)
+
+    def test_start_end_match(self):
+        # the new itinerary start date matches the end date of a
+        # current itinerary
+        currency = PublicsCurrencyFactory()
+        dsa_region = PublicsDSARegionFactory()
+
+        data = {'itinerary': [{'origin': 'Berlin',
+                               'destination': 'Budapest',
+                               'departure_date': '2017-04-14T17:06:55.821490',
+                               'arrival_date': '2017-04-20T17:06:55.821490',
+                               'dsa_region': dsa_region.id,
+                               'overnight_travel': False,
+                               'mode_of_travel': ModeOfTravel.RAIL,
+                               'airlines': []},
+                              {'origin': 'Budapest',
+                               'destination': 'Berlin',
+                               'departure_date': '2017-05-20T12:06:55.821490',
+                               'arrival_date': '2017-05-21T12:06:55.821490',
+                               'dsa_region': dsa_region.id,
+                               'overnight_travel': False,
+                               'mode_of_travel': ModeOfTravel.RAIL,
+                               'airlines': []}],
+                'activities': [],
+                'ta_required': True,
+                'international_travel': False,
+                'mode_of_travel': [ModeOfTravel.BOAT],
+                'traveler': self.traveler.id,
+                'supervisor': self.unicef_staff.id,
+                'start_date': '2017-04-14T15:06:55+01:00',
+                'end_date': '2017-05-22T15:02:13+01:00',
+                'currency': currency.id,
+                'purpose': 'Purpose',
+                'additional_note': 'Notes'}
+
+        response = self.forced_auth_req(
+            'post',
+            reverse('t2f:travels:list:index'),
+            data=data,
+            user=self.traveler,
+        )
+        response_json = json.loads(response.rendered_content)
+
+        travel_id = response_json['id']
+
+        response = self.forced_auth_req(
+            'post',
+            reverse(
+                't2f:travels:details:state_change',
+                kwargs={
+                    'travel_pk': travel_id,
+                    'transition_name': Travel.SUBMIT_FOR_APPROVAL,
+                }
+            ),
+            data=response_json,
+            user=self.traveler,
+        )
+        assert response.status_code == 200
+
+    def test_end_start_match(self):
+        # the new itinerary end date matches the start date
+        # of a current itinerary
+        currency = PublicsCurrencyFactory()
+        dsa_region = PublicsDSARegionFactory()
+
+        data = {'itinerary': [{'origin': 'Berlin',
+                               'destination': 'Budapest',
+                               'departure_date': '2017-03-14T17:06:55.821490',
+                               'arrival_date': '2017-03-20T17:06:55.821490',
+                               'dsa_region': dsa_region.id,
+                               'overnight_travel': False,
+                               'mode_of_travel': ModeOfTravel.RAIL,
+                               'airlines': []},
+                              {'origin': 'Budapest',
+                               'destination': 'Berlin',
+                               'departure_date': '2017-03-25T12:06:55.821490',
+                               'arrival_date': '2017-04-04T12:06:55.821490',
+                               'dsa_region': dsa_region.id,
+                               'overnight_travel': False,
+                               'mode_of_travel': ModeOfTravel.RAIL,
+                               'airlines': []}],
+                'activities': [],
+                'ta_required': True,
+                'international_travel': False,
+                'mode_of_travel': [ModeOfTravel.BOAT],
+                'traveler': self.traveler.id,
+                'supervisor': self.unicef_staff.id,
+                'start_date': '2017-03-14T15:06:55+01:00',
+                'end_date': '2017-04-04T15:02:13+01:00',
+                'currency': currency.id,
+                'purpose': 'Purpose',
+                'additional_note': 'Notes'}
+
+        response = self.forced_auth_req(
+            'post',
+            reverse('t2f:travels:list:index'),
+            data=data,
+            user=self.traveler,
+        )
+        response_json = json.loads(response.rendered_content)
+
+        travel_id = response_json['id']
+
+        response = self.forced_auth_req(
+            'post',
+            reverse(
+                't2f:travels:details:state_change',
+                kwargs={
+                    'travel_pk': travel_id,
+                    'transition_name': Travel.SUBMIT_FOR_APPROVAL,
+                }
+            ),
+            data=response_json,
+            user=self.traveler,
+        )
+        assert response.status_code == 200


### PR DESCRIPTION
[ch10004]

Ensure overlapping dates are validated/checked in Approved, and Completed status changes as well.

There is a `validate_itinerary` method, which is used for transition to `Submitted` status, I'd recommend moving the validation in the serializer to this, and using this validation for the other transitions `Approved` and `Completed`.

Kept this PR simply as I believe we're wanting to make a quick release.