### PR TITLE
Fixed datetime less than check in 'send_intervention_draft_notification'

### DIFF
--- a/src/etools/applications/partners/utils.py
+++ b/src/etools/applications/partners/utils.py
@@ -442,7 +442,7 @@ def send_intervention_draft_notification():
     """Send an email to PD/SHPD/SSFA's focal point(s) if in draft status"""
     for intervention in Intervention.objects.filter(
             status=Intervention.DRAFT,
-            created__lt=datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7),
+            created__lt=(datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=7)).date(),
     ):
         recipients = [
             u.user.email for u in intervention.unicef_focal_points.all()


### PR DESCRIPTION
[ch10191]

 - strip time from the datetime used in the check, so it works exactly like before, just timezone aware