### PR TITLE
Gracefully handle redis being down

### DIFF
--- a/src/etools/config/settings/base.py
+++ b/src/etools/config/settings/base.py
@@ -67,7 +67,7 @@ def get_from_secrets_or_env(var_name, default=None):
 # DJANGO: CACHE
 CACHES = {
     'default': {
-        'BACKEND': 'redis_cache.RedisCache',
+        'BACKEND': 'etools.libraries.redis_cache.base.eToolsCache',
         'LOCATION': get_from_secrets_or_env('REDIS_URL', 'redis://localhost:6379/0')
     }
 }

--- a/src/etools/libraries/redis_cache/base.py
+++ b/src/etools/libraries/redis_cache/base.py
@@ -1,0 +1,95 @@
+from redis.exceptions import ConnectionError
+from redis_cache import RedisCache
+from redis_cache.backends.base import DEFAULT_TIMEOUT, get_client
+
+
+class eToolsCache(RedisCache):
+    def _get(self, client, key, default=None):
+        try:
+            value = super()._get(client, key, default)
+        except ConnectionError:
+            value = default
+        return value
+
+    def _set(self, client, key, value, timeout, _add_only=False):
+        try:
+            result = super()._set(client, key, value, timeout, _add_only)
+        except ConnectionError:
+            result = value
+        return value
+
+    def _delete_many(self, client, keys):
+        try:
+            super()._delete_many(client, keys)
+        except ConnectionError:
+            pass
+
+    def _clear(self, client):
+        try:
+            super()._clear(client)
+        except ConnectionError:
+            pass
+
+    def _get_many(self, client, original_keys, versioned_keys):
+        try:
+            data = super()._get_many(client, original_keys, versioned_keys)
+        except ConnectionError:
+            data = {}
+        return data
+
+    def _incr_version(self, client, old, new, original, delta, version):
+        try:
+            result = super()._incr_version(
+                client,
+                old,
+                new,
+                original,
+                delta,
+                version,
+            )
+        except ConnectionError:
+            result = None
+        return result
+
+    def _delete_pattern(self, client, pattern):
+        try:
+            super()._delete_pattern(client, pattern)
+        except ConnectionError:
+            pass
+
+    def get_or_set(
+            self,
+            key,
+            func,
+            timeout=DEFAULT_TIMEOUT,
+            lock_timeout=None,
+            stale_cache_timeout=None,
+    ):
+        try:
+            value = super().get_or_set(
+                key,
+                func,
+                timeout=timeout,
+                lock_timeout=lock_timeout,
+                stale_cache_timeout=stale_cache_timeout,
+            )
+        except ConnectionError:
+            try:
+                value = func()
+            except Exception:
+                raise
+        return value
+
+    def incr(self, key, delta=1):
+        try:
+            value = super().incr(key, delta=delta)
+        except ConnectionError:
+            value = delta
+        return value
+
+    def delete(self, key):
+        try:
+            result = super().delete(key)
+        except ConnectionError:
+            result = True
+        return result

--- a/src/etools/libraries/redis_cache/base.py
+++ b/src/etools/libraries/redis_cache/base.py
@@ -1,6 +1,6 @@
 from redis.exceptions import ConnectionError
 from redis_cache import RedisCache
-from redis_cache.backends.base import DEFAULT_TIMEOUT, get_client
+from redis_cache.backends.base import DEFAULT_TIMEOUT
 
 
 class eToolsCache(RedisCache):
@@ -16,7 +16,7 @@ class eToolsCache(RedisCache):
             result = super()._set(client, key, value, timeout, _add_only)
         except ConnectionError:
             result = value
-        return value
+        return result
 
     def _delete_many(self, client, keys):
         try:


### PR DESCRIPTION
[ch11092]

If there is a connection error with redis/cache, then continue as normal.

To test locally, comment out the `CACHE` setting in `src/etools/config/settings/local.py` and make sure redis is not up.

The following tests will fail, as they are actually testing caching;

```
src/etools/applications/environment/tests/test_models.py:85:    def test_is_active_function_cached(self):
src/etools/applications/environment/tests/test_models.py:100:    def test_user_set_is_cached(self):
src/etools/applications/environment/tests/test_models.py:109:    def test_empty_user_set_is_cached(self):
src/etools/applications/environment/tests/test_models.py:117:    def test_group_set_is_cached(self):
src/etools/applications/environment/tests/test_models.py:276:    def test_is_active_function_is_cached(self):
src/etools/libraries/locations/tests/test_views.py:73:    def test_api_location_list_cached(self):
```