### PR TITLE
Clean up PSEA available actions for cancelled status

### DIFF
--- a/src/etools/applications/psea/serializers.py
+++ b/src/etools/applications/psea/serializers.py
@@ -141,7 +141,11 @@ class AssessmentSerializer(BaseAssessmentSerializer):
             if obj.status in [obj.STATUS_SUBMITTED]:
                 available_actions.append(ACTION_MAP.get(obj.STATUS_REJECTED))
                 available_actions.append(ACTION_MAP.get(obj.STATUS_FINAL))
-            if obj.status not in [obj.STATUS_FINAL]:
+            if obj.status not in [
+                    obj.STATUS_CANCELLED,
+                    obj.STATUS_SUBMITTED,
+                    obj.STATUS_FINAL,
+            ]:
                 available_actions.append(ACTION_MAP.get(obj.STATUS_CANCELLED))
         if obj.user_is_assessor(user):
             if obj.status in [obj.STATUS_IN_PROGRESS, obj.STATUS_REJECTED]:


### PR DESCRIPTION
Cancelled action should not be available in `Cancelled`, and `Submitted` states