### PR TITLE
Tweak OfficeViewSet get_queryset

### DIFF
--- a/src/etools/applications/users/views.py
+++ b/src/etools/applications/users/views.py
@@ -291,11 +291,10 @@ class OfficeViewSet(ExternalModuleFilterMixin,
     """
     serializer_class = OfficeSerializer
     permission_classes = (IsAuthenticatedOrReadOnly,)
-    queryset = Office.objects.all()
     module2filters = {'tpm': ['tpmactivity__tpm_visit__tpm_partner__staff_members__user', ]}
 
     def get_queryset(self):
-        qs = super().get_queryset()
+        qs = Office.objects.all()
         if "values" in self.request.query_params.keys():
             # Used for ghost data - filter in all(), and return straight away.
             try:


### PR DESCRIPTION
Attempting to fix issue with all offices being returned by endpoint `/api/offices/` instead of those just within the users selected `country`

Not able to reproduce this exact issue locally, but was not getting any offices.

Locally was seeing strange issue with returned qs from super() not matching
qs in ModelManager