### PR TITLE
Exclude Global tenant from overdue notifications on action_points task

### DIFF
--- a/src/etools/applications/action_points/tasks.py
+++ b/src/etools/applications/action_points/tasks.py
@@ -19,7 +19,7 @@ def notify_overdue_action_points():
     """Send a notification to assignee of an action for each
     overdue action point (day after due date)
     """
-    for country in Country.objects.exclude(name=get_public_schema_name()).all():
+    for country in Country.objects.exclude(name__in=[get_public_schema_name(), 'Global']).all():
         connection.set_tenant(country)
         _notify_overdue_action_points(country.name)
 


### PR DESCRIPTION
Correct issue on `Global` tenant schema, now exclude that schema from task

```
UndefinedTable: relation "action_points_actionpoint" does not exist
LINE 1: ...ion_points_actionpoint"."date_of_completion" FROM "action_po...
                                                             ^

  File "django/db/backends/utils.py", line 84, in _execute
    return self.cursor.execute(sql, params)
  File "newrelic/hooks/database_psycopg2.py", line 51, in execute
    **kwargs)
  File "newrelic/hooks/database_dbapi2.py", line 25, in execute
    *args, **kwargs)
```