### PR TITLE
Update get mail context methods to not pass in objects

### DIFF
--- a/src/etools/applications/psea/models.py
+++ b/src/etools/applications/psea/models.py
@@ -2,7 +2,6 @@ from django.conf import settings
 from django.db import connection, models
 from django.db.models import Sum
 from django.utils import timezone
-from django.utils.encoding import force_text
 from django.utils.translation import ugettext_lazy as _
 
 from django_fsm import FSMField, transition
@@ -220,9 +219,12 @@ class Assessment(TimeStampedModel):
 
     def get_mail_context(self, user):
         context = {
-            "partner": force_text(self.partner),
+            "partner_name": self.partner.name,
+            "partner_vendor_number": self.partner.vendor_number,
             "url": self.get_object_url(user=user),
-            "assessment": force_text(self),
+            "overall_rating": self.overall_rating,
+            "assessment_date": str(self.assessment_date),
+            "assessor": str(self.assessor),
         }
         if self.status == self.STATUS_REJECTED:
             context["rejected_comment"] = self.get_rejected_comment()

--- a/src/etools/applications/psea/notifications/assessment-assigned.py
+++ b/src/etools/applications/psea/notifications/assessment-assigned.py
@@ -1,19 +1,19 @@
 name = 'psea/assessment/assigned'
 defaults = {
     'description': 'PSEA Assessment Assigned.',
-    'subject': 'PSEA Assessment Assigned for {{ partner.name }}',
+    'subject': 'PSEA Assessment Assigned for {{ partner_name }}',
     'content': """
     Dear Colleagues,
 
     Please note that a PSEA assessment was assigned for the following Partner:
 
-    Vendor Number: {{ partner.vendor_number }}
+    Vendor Number: {{ partner_vendor_number }}
 
-    Vendor Name: {{ partner.name }}
+    Vendor Name: {{ partner_name }}
 
-    PSEA Risk Rating: {{ assessment.overall_rating }}
+    PSEA Risk Rating: {{ overall_rating }}
 
-    Date of Assessment: {{ assessment.assessment_date }}
+    Date of Assessment: {{ assessment_date }}
 
     Please update the Vendor Master Data in VISION accordingly
 

--- a/src/etools/applications/psea/notifications/assessment-final.py
+++ b/src/etools/applications/psea/notifications/assessment-final.py
@@ -1,15 +1,15 @@
 name = 'psea/assessment/final'
 defaults = {
     'description': 'PSEA Assessment Final.',
-    'subject': 'PSEA Assessment for {{ partner.name }}',
+    'subject': 'PSEA Assessment for {{ partner_name }}',
     'content': """
     Dear Colleagues,
 
     Please note that a PSEA assessment has been assigned for the following Partner:
 
-    Vendor Number: {{ partner.vendor_number }}
+    Vendor Number: {{ partner_vendor_number }}
 
-    Vendor Name: {{ partner.name }}
+    Vendor Name: {{ partner_name }}
 
     Please click <a href="{{ url }}">this link</a> to complete the report.<br/><br/>
 

--- a/src/etools/applications/psea/notifications/assessment-rejected.py
+++ b/src/etools/applications/psea/notifications/assessment-rejected.py
@@ -1,17 +1,17 @@
 name = 'psea/assessment/rejected'
 defaults = {
     'description': 'PSEA Assessment Rejected.',
-    'subject': 'PSEA Assessment Rejected for {{ partner.name }}',
+    'subject': 'PSEA Assessment Rejected for {{ partner_name }}',
     'content': """
     Dear Colleagues,
 
     Please note that a PSEA assessment has been rejected for the following Partner:
 
-    Vendor Number: {{ partner.vendor_number }}
+    Vendor Number: {{ partner_vendor_number }}
 
-    Vendor Name: {{ partner.name }}
+    Vendor Name: {{ partner_name }}
 
-    Date of Assessment: {{ assessment.assessment_date }}
+    Date of Assessment: {{ assessment_date }}
 
     Comment: {{ rejected_comment }}
 

--- a/src/etools/applications/psea/notifications/assessment-submitted.py
+++ b/src/etools/applications/psea/notifications/assessment-submitted.py
@@ -1,16 +1,16 @@
 name = 'psea/assessment/submitted'
 defaults = {
     'description': 'Email sent to focal points when PSEA assessment has been submitted by external vendor.',
-    'subject': 'PSEA Assessment Submitted: {{ partner.name }}',
+    'subject': 'PSEA Assessment Submitted: {{ partner_name }}',
 
     'content': """
     Dear Colleague,
 
     Please note that a PSEA assessment for the following partner has been submitted:
 
-    Vendor Number: {{ partner.vendor_number }}
+    Vendor Number: {{ partner_vendor_number }}
 
-    Vendor Name: {{ partner.name }}
+    Vendor Name: {{ partner_name }}
 
     Assessor: {{ assessor }}
 

--- a/src/etools/applications/psea/signals.py
+++ b/src/etools/applications/psea/signals.py
@@ -9,12 +9,12 @@ def action_point_updated_receiver(instance, created, **kwargs):
     if created:
         instance.send_email(
             instance.assigned_to,
-            'audit/engagement/action_point_assigned',
+            'psea/assessment/action_point_assigned',
             cc=[instance.assigned_by.email],
         )
     else:
         if instance.tracker.has_changed('assigned_to'):
             instance.send_email(
                 instance.assigned_to,
-                'audit/engagement/action_point_assigned',
+                'psea/assessment/action_point_assigned',
             )

--- a/src/etools/applications/psea/tests/test_models.py
+++ b/src/etools/applications/psea/tests/test_models.py
@@ -182,10 +182,14 @@ class TestAssessment(BaseTenantTestCase):
     def test_get_mail_context(self):
         user = UserFactory()
         assessment = AssessmentFactory()
+        AssessorFactory(assessment=assessment)
         self.assertEqual(assessment.get_mail_context(user), {
-            "partner": assessment.partner.name,
+            "partner_name": assessment.partner.name,
+            "partner_vendor_number": assessment.partner.vendor_number,
             "url": assessment.get_object_url(user=user),
-            "assessment": str(assessment),
+            "overall_rating": assessment.overall_rating,
+            "assessment_date": str(assessment.assessment_date),
+            "assessor": str(assessment.assessor),
         })
 
     def test_get_reference_number(self):
@@ -218,14 +222,18 @@ class TestAssessmentActionPoint(BaseTenantTestCase):
     def test_get_mail_context(self):
         user = UserFactory()
         assessment = AssessmentFactory()
+        AssessorFactory(assessment=assessment)
         ap = AssessmentActionPointFactory(
             psea_assessment=assessment,
         )
         context = ap.get_mail_context(user=user)
         self.assertEqual(context["psea_assessment"], {
-            "partner": assessment.partner.name,
+            "partner_name": assessment.partner.name,
+            "partner_vendor_number": assessment.partner.vendor_number,
             "url": assessment.get_object_url(user=user),
-            "assessment": str(assessment),
+            "overall_rating": assessment.overall_rating,
+            "assessment_date": str(assessment.assessment_date),
+            "assessor": str(assessment.assessor),
         })
 
 

--- a/src/etools/applications/psea/tests/test_views.py
+++ b/src/etools/applications/psea/tests/test_views.py
@@ -634,6 +634,7 @@ class TestAssessmentViewSet(BaseTenantTestCase):
         assessment.save()
         assessment.focal_points.add(self.focal_user)
         AnswerFactory(assessment=assessment)
+        AssessorFactory(assessment=assessment)
         self.assertEqual(assessment.status, assessment.STATUS_IN_PROGRESS)
 
         mock_send = Mock()
@@ -659,6 +660,7 @@ class TestAssessmentViewSet(BaseTenantTestCase):
         assessment.status = assessment.STATUS_SUBMITTED
         assessment.save()
         AnswerFactory(assessment=assessment)
+        AssessorFactory(assessment=assessment)
         self.assertEqual(assessment.status, assessment.STATUS_SUBMITTED)
         mock_send = Mock()
         with patch(self.send_path, mock_send):
@@ -979,6 +981,7 @@ class TestAssessmentActionPointViewSet(BaseTenantTestCase):
         assessment.status = Assessment.STATUS_FINAL
         assessment.save()
         assessment.focal_points.set([self.focal_user])
+        AssessorFactory(assessment=assessment)
         self.assertEqual(assessment.action_points.count(), 0)
 
         mock_send = Mock()


### PR DESCRIPTION
[ch16110]

Need to ensure that `update_notifications` is run when updating the various regions. Appears that this was not done on the previous release to staging as email template is showing old template.

There are no HTML versions of these psea notifications, are we wanting that?