### PR TITLE
[Field Monitoring] Fix unlinked pd/ssfa validation

### DIFF
--- a/src/etools/applications/field_monitoring/planning/activity_validation/validations/basic.py
+++ b/src/etools/applications/field_monitoring/planning/activity_validation/validations/basic.py
@@ -30,7 +30,8 @@ def interventions_connected_with_partners(i):
 
     diff = set(partners) - set(i.partners.values_list('id', flat=True))
     if diff:
-        error_text = _('Unlinked PD/SSFA detected. Please remove corresponding partners first: {}')
+        error_text = _("You've selected a PD/SSFA and unselected some of it's corresponding partners, "
+                       "please either remove the PD or add the partners back before saving: {}")
         wrong_partners = PartnerOrganization.objects.filter(id__in=diff).values_list('name', flat=True)
         raise BasicValidationError(error_text.format(', '.join(wrong_partners)))
 
@@ -40,12 +41,14 @@ def interventions_connected_with_partners(i):
 def interventions_connected_with_cp_outputs(i):
     current_cp = CountryProgramme.main_active()
     cp_outputs = i.interventions.filter(
+        result_links__isnull=False,
         result_links__cp_output__country_programme=current_cp
     ).values_list('result_links__cp_output', flat=True)
 
     diff = set(cp_outputs) - set(i.cp_outputs.values_list('id', flat=True))
     if diff:
-        error_text = _('Unlinked PD/SSFA detected. Please remove corresponding outputs first: {}')
+        error_text = _("You've selected a PD/SSFA and unselected some of it's corresponding outputs, "
+                       "please either remove the PD or add the outputs back before saving: {}")
         wrong_cp_outputs = Result.objects.filter(id__in=diff).values_list('name', flat=True)
         raise BasicValidationError(error_text.format(', '.join(wrong_cp_outputs)))
 

--- a/src/etools/applications/field_monitoring/planning/activity_validation/validations/basic.py
+++ b/src/etools/applications/field_monitoring/planning/activity_validation/validations/basic.py
@@ -4,7 +4,7 @@ from etools_validator.exceptions import BasicValidationError
 
 from etools.applications.field_monitoring.planning.models import MonitoringActivity
 from etools.applications.partners.models import PartnerOrganization
-from etools.applications.reports.models import Result
+from etools.applications.reports.models import CountryProgramme, Result
 
 
 def staff_activity_has_no_tpm_partner(i):
@@ -38,7 +38,10 @@ def interventions_connected_with_partners(i):
 
 
 def interventions_connected_with_cp_outputs(i):
-    cp_outputs = i.interventions.values_list('result_links__cp_output', flat=True)
+    current_cp = CountryProgramme.main_active()
+    cp_outputs = i.interventions.filter(
+        result_links__cp_output__country_programme=current_cp
+    ).values_list('result_links__cp_output', flat=True)
 
     diff = set(cp_outputs) - set(i.cp_outputs.values_list('id', flat=True))
     if diff:

--- a/src/etools/applications/field_monitoring/planning/tests/test_models.py
+++ b/src/etools/applications/field_monitoring/planning/tests/test_models.py
@@ -23,7 +23,7 @@ from etools.applications.partners.tests.factories import (
     InterventionResultLinkFactory,
     PartnerFactory,
 )
-from etools.applications.reports.models import ResultType, CountryProgramme
+from etools.applications.reports.models import CountryProgramme, ResultType
 from etools.applications.reports.tests.factories import CountryProgrammeFactory, ResultFactory, SectionFactory
 from etools.applications.tpm.tests.factories import TPMPartnerFactory, TPMPartnerStaffMemberFactory
 

--- a/src/etools/applications/field_monitoring/planning/tests/test_models.py
+++ b/src/etools/applications/field_monitoring/planning/tests/test_models.py
@@ -1,3 +1,8 @@
+from datetime import timedelta
+
+from dateutil.utils import today
+from factory import fuzzy
+
 from etools.applications.core.tests.cases import BaseTenantTestCase
 from etools.applications.field_monitoring.data_collection.models import (
     ActivityOverallFinding,
@@ -13,8 +18,13 @@ from etools.applications.field_monitoring.planning.tests.factories import (
     QuestionTemplateFactory,
 )
 from etools.applications.field_monitoring.tests.factories import UserFactory
-from etools.applications.partners.tests.factories import InterventionFactory, PartnerFactory
-from etools.applications.reports.tests.factories import SectionFactory
+from etools.applications.partners.tests.factories import (
+    InterventionFactory,
+    InterventionResultLinkFactory,
+    PartnerFactory,
+)
+from etools.applications.reports.models import ResultType
+from etools.applications.reports.tests.factories import CountryProgrammeFactory, ResultFactory, SectionFactory
 from etools.applications.tpm.tests.factories import TPMPartnerFactory, TPMPartnerStaffMemberFactory
 
 
@@ -67,6 +77,17 @@ class TestMonitoringActivityValidations(BaseTenantTestCase):
         activity = MonitoringActivityFactory(status=MonitoringActivity.STATUSES.draft, monitor_type='staff',
                                              interventions=[intervention], partners=[intervention.agreement.partner])
         self.assertFalse(ActivityValid(activity, user=self.user).is_valid)
+
+    def test_interventions_output_expiring(self):
+        intervention = InterventionFactory()
+        previous_country_programme = CountryProgrammeFactory(wbs='/A0/' + fuzzy.FuzzyText().fuzz(),
+                                                             from_date=today() - timedelta(days=365),
+                                                             to_date=today() - timedelta(days=2))
+        output = ResultFactory(result_type__name=ResultType.OUTPUT, country_programme=previous_country_programme)
+        InterventionResultLinkFactory(cp_output=output, intervention=intervention)
+        activity = MonitoringActivityFactory(status=MonitoringActivity.STATUSES.draft, monitor_type='staff',
+                                             interventions=[intervention], partners=[intervention.agreement.partner])
+        self.assertTrue(ActivityValid(activity, user=self.user).is_valid)
 
     def test_activity_overall_findings_required_narrative_finding(self):
         activity = MonitoringActivityFactory(status=MonitoringActivity.STATUSES.submitted)


### PR DESCRIPTION
ignoring outputs not connected to the current country programme while validating monitored entities relations
clubhouse#17914