### PR TITLE
[FIeld Monitoring] Update data collection methods fixture

### DIFF
--- a/src/etools/applications/core/data/field_monitoring_methods.json
+++ b/src/etools/applications/core/data/field_monitoring_methods.json
@@ -25,5 +25,23 @@
             "short_name": "Obs.",
             "use_information_source": false
         }
+    },
+    {
+        "model": "field_monitoring_settings.method",
+        "pk": 4,
+        "fields": {
+            "name": "Measurement",
+            "short_name": "M",
+            "use_information_source": false
+        }
+    },
+    {
+        "model": "field_monitoring_settings.method",
+        "pk": 5,
+        "fields": {
+            "name": "Participatory appraisal",
+            "short_name": "PA",
+            "use_information_source": true
+        }
     }
 ]

--- a/src/etools/applications/field_monitoring/fm_settings/tests/test_views.py
+++ b/src/etools/applications/field_monitoring/fm_settings/tests/test_views.py
@@ -43,7 +43,7 @@ class MethodsViewTestCase(FMBaseTestCaseMixin, BaseTenantTestCase):
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(len(response.data['results']), 3)
+        self.assertEqual(len(response.data['results']), 5)
 
 
 class LocationsViewTestCase(FMBaseTestCaseMixin, BaseTenantTestCase):


### PR DESCRIPTION
[ch18215]
added Measurement & Participatory appraisal to fm methods fixture
fixture should be loaded with `python manage.py tenant_loaddata field_monitoring_methods`