### PR TITLE
Update target_display to handle missing indicator on AppliedIndicator

### DIFF
--- a/src/etools/applications/reports/models.py
+++ b/src/etools/applications/reports/models.py
@@ -659,7 +659,7 @@ class AppliedIndicator(TimeStampedModel):
 
     @cached_property
     def target_display(self):
-        ind_type = self.indicator.display_type
+        ind_type = self.indicator.display_type if self.indicator else None
         numerator = self.target.get('v', self.target)
         denominator = '-'
         if ind_type == IndicatorBlueprint.RATIO:

--- a/src/etools/applications/reports/serializers/v2.py
+++ b/src/etools/applications/reports/serializers/v2.py
@@ -171,11 +171,15 @@ class AppliedIndicatorSerializer(serializers.ModelSerializer):
                     'You cannot change the Indicator Target Denominator if PD/SSFA is '
                     'not in status Draft or Signed'
                 ))
-            if attrs['target']['d'] != self.instance.target_display[1] \
-               and not (
-                   status in [Intervention.DRAFT, Intervention.SIGNED] or (
-                    status == Intervention.ACTIVE and in_amendment and
-                    self.instance.indicator.display_type != IndicatorBlueprint.RATIO)):
+            if attrs['target']['d'] != self.instance.target_display[1] and not (
+                    status in [Intervention.DRAFT, Intervention.SIGNED] or (
+                        status == Intervention.ACTIVE and in_amendment and
+                        (
+                            self.instance.indicator and
+                            self.instance.indicator.display_type != IndicatorBlueprint.RATIO
+                        )
+                    )
+            ):
                 raise ValidationError(_(
                     'You cannot change the Indicator Target Denominator if PD/SSFA is '
                     'not in status Draft or Signed'


### PR DESCRIPTION
[ch18196]

`Indicator` field is allowed to be None on `AppliedIndicator`