### PR TITLE
Remove prefetching of locations in prp interventions endpoint

### DIFF
--- a/src/etools/applications/partners/serializers/prp_v1.py
+++ b/src/etools/applications/partners/serializers/prp_v1.py
@@ -167,7 +167,7 @@ class PRPIndicatorSerializer(serializers.ModelSerializer):
             l["pcode"] = l.pop("p_code")
             l["location_type"] = l.pop("gateway__name")
             l["admin_level"] = l.pop("gateway__admin_level")
-        return location_qs
+        return list(location_qs)
 
     class Meta:
         model = AppliedIndicator

--- a/src/etools/applications/partners/serializers/prp_v1.py
+++ b/src/etools/applications/partners/serializers/prp_v1.py
@@ -141,7 +141,7 @@ class PRPIndicatorSerializer(serializers.ModelSerializer):
     unit = serializers.SerializerMethodField()
     display_type = serializers.SerializerMethodField()
     blueprint_id = serializers.PrimaryKeyRelatedField(source='indicator', read_only=True)
-    locations = PRPLocationSerializer(read_only=True, many=True)
+    locations = serializers.SerializerMethodField()
     disaggregation = DisaggregationSerializer(read_only=True, many=True)
     target = serializers.JSONField(required=False)
     baseline = serializers.JSONField(required=False)
@@ -154,6 +154,20 @@ class PRPIndicatorSerializer(serializers.ModelSerializer):
 
     def get_display_type(self, ai):
         return ai.indicator.display_type if ai.indicator else ''
+
+    def get_locations(self, obj):
+        location_qs = obj.locations.values(
+            "id",
+            "name",
+            "p_code",
+            "gateway__name",
+            "gateway__admin_level",
+        )
+        for l in location_qs:
+            l["pcode"] = l.pop("p_code")
+            l["location_type"] = l.pop("gateway__name")
+            l["admin_level"] = l.pop("gateway__admin_level")
+        return location_qs
 
     class Meta:
         model = AppliedIndicator

--- a/src/etools/applications/partners/views/prp_v1.py
+++ b/src/etools/applications/partners/views/prp_v1.py
@@ -63,7 +63,6 @@ class PRPInterventionListAPIView(QueryStringFilterMixin, ListAPIView):
         'result_links__ll_results',
         'result_links__ll_results__applied_indicators__indicator',
         'result_links__ll_results__applied_indicators__disaggregation__disaggregation_values',
-        'result_links__ll_results__applied_indicators__locations',
         'special_reporting_requirements',
         'reporting_requirements',
         'frs',


### PR DESCRIPTION
[ch20711]

Use `values()` query for location data in `PRPIndicatorSerializer` sub-serializer.

Locally endpoint was taking ~12s before changes and now taking ~3s