### PR TITLE
Refresh psea attachment serializer instance after saving

### DIFF
--- a/src/etools/applications/psea/views.py
+++ b/src/etools/applications/psea/views.py
@@ -555,6 +555,7 @@ class AnswerAttachmentsViewSet(
             pk=serializer.initial_data.get("id")
         )
         serializer.save(content_object=self.get_parent_object())
+        serializer.instance.refresh_from_db()
 
     def perform_update(self, serializer):
         serializer.save(content_object=self.get_parent_object())


### PR DESCRIPTION
This is an attempt to fix the issue whereby attachments are not showing in the responding payload when adding a psea attachment.