### PR TITLE
Ensure IsAuthenticated permissions is used

### DIFF
--- a/src/etools/applications/core/views.py
+++ b/src/etools/applications/core/views.py
@@ -5,6 +5,7 @@ from django.shortcuts import redirect
 from django.urls import reverse
 from django.views.generic import RedirectView
 
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework_jwt.serializers import jwt_encode_handler, jwt_payload_handler
@@ -22,7 +23,7 @@ class MainView(RedirectView):
 
 
 class IssueJWTRedirectView(APIView):
-    permission_classes = ()
+    permission_classes = [IsAuthenticated]
 
     def get(self, request):
         user = self.request.user

--- a/src/etools/applications/field_monitoring/data_collection/views.py
+++ b/src/etools/applications/field_monitoring/data_collection/views.py
@@ -7,7 +7,7 @@ from django_filters.rest_framework import DjangoFilterBackend
 from rest_framework import mixins, status, viewsets
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
-from rest_framework.permissions import AllowAny
+from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from unicef_attachments.models import Attachment
 from unicef_restlib.views import NestedViewSetMixin
@@ -68,7 +68,7 @@ class ActivityDataCollectionViewSet(
     # todo: change permission_classes to something else to filter out non-offline backend calls
     @action(
         detail=True, methods=['POST'], url_path=r'offline/(?P<method_pk>\d+)', url_name='offline',
-        permission_classes=[AllowAny],
+        permission_classes=[IsAuthenticated],
     )
     def offline(self, request, *args, method_pk=None, **kwargs):
         workspace = request.query_params.get('workspace', None)

--- a/src/etools/applications/reports/tests/test_views.py
+++ b/src/etools/applications/reports/tests/test_views.py
@@ -2,9 +2,10 @@ import datetime
 from operator import itemgetter
 
 from django.test import SimpleTestCase
-from django.urls import reverse
+from django.urls import resolve, reverse
 
 from rest_framework import status
+from rest_framework.test import APIRequestFactory
 from tablib.core import Dataset
 
 from etools.applications.core.tests.cases import BaseTenantTestCase
@@ -281,6 +282,11 @@ class TestDisaggregationListCreateViews(BaseTenantTestCase):
         cls.group = GroupFactory(name="PME")
         cls.pme_user.groups.add(cls.group)
         cls.url = reverse('reports:disaggregation-list-create')
+
+    def test_unauthed(self):
+        request = APIRequestFactory().get(self.url, format="json")
+        response = resolve(self.url).func(request)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_get(self):
         """

--- a/src/etools/applications/reports/views/v2.py
+++ b/src/etools/applications/reports/views/v2.py
@@ -227,13 +227,13 @@ class LowerResultsDeleteView(DestroyAPIView):
 class DisaggregationListCreateView(ListCreateAPIView):
     serializer_class = DisaggregationSerializer
     queryset = Disaggregation.objects.all()
-    permission_classes = (PMEPermission, )
+    permission_classes = (IsAuthenticated, PMEPermission, )
 
 
 class DisaggregationRetrieveUpdateView(RetrieveUpdateAPIView):
     serializer_class = DisaggregationSerializer
     queryset = Disaggregation.objects.all()
-    permission_classes = (PMEPermission, )
+    permission_classes = (IsAuthenticated, PMEPermission, )
 
 
 class AppliedIndicatorListAPIView(ExportModelMixin, ListAPIView):


### PR DESCRIPTION
[ch17961]

The default permission class is `IsAuthenticated`

Fixed all permission_classes that attempted to override this default still included `IsAuthenticated` permissions.

The following places were specific about providing "open" access;
- https://github.com/unicef/etools/blob/develop/src/etools/applications/field_monitoring/data_collection/views.py#L71
- https://github.com/unicef/etools/blob/develop/src/etools/applications/core/views.py#L25
- https://github.com/unicef/etools/blob/develop/src/etools/applications/partners/views/prp_v1.py#L23

Are these places ok to be more "open"?