### PR TITLE
Add pmp attachment file type endpoint

### DIFF
--- a/src/etools/applications/attachments/management/commands/init-attachment-file-types.py
+++ b/src/etools/applications/attachments/management/commands/init-attachment-file-types.py
@@ -11,18 +11,20 @@ from etools.libraries.tenant_support.utils import run_on_all_tenants
 logger = logging.getLogger(__name__)
 
 FILE_TYPES_MAPPING = [
-    # ("code", "label", "name", "order"),
-    ("partners_agreement", "Signed Agreement", "attached_agreement", 0),
-    ("partners_partner_assessment", "Core Values Assessment", "core_values_assessment", 0),
-    ("partners_assessment_report", "Assessment Report", "assessment_report", 0),
-    ("partners_agreement_amendment", "Agreement Amendment", "agreement_signed_amendment", 0),
-    ("partners_intervention_prc_review", "PRC Review", "intervention_prc_review", 0),
-    ("partners_intervention_signed_pd", "Signed PD/SSFA", "intervention_signed_pd", 0),
-    ("partners_intervention_activation_letter", "PD Activation Letter", "activation_letter", 0),
-    ("partners_intervention_termination_doc", "PD Termination Document", "termination_doc", 0),
-    ("partners_intervention_amendment_signed", "PD/SSFA Amendment", "intervention_amendment_signed", 0),
-    ("partners_intervention_attachment", "Intervention Attachment", "intervention_attachment", 0),
-    ("t2f_travel_attachment", "Travel Attachment", "t2f_travel_attachment", 0),
+    # ("code", "label", "name", "order", "group"),
+    ("partners_agreement", "Signed Agreement", "attached_agreement", 0, ["pmp"]),
+    ("partners_partner_assessment", "Core Values Assessment", "core_values_assessment", 0, ["pmp"]),
+    ("partners_assessment_report", "Assessment Report", "assessment_report", 0, ["pmp"]),
+    ("partners_agreement_amendment", "Agreement Amendment", "agreement_signed_amendment", 0, ["pmp"]),
+    ("partners_intervention_prc_review", "PRC Review", "intervention_prc_review", 0, ["pmp"]),
+    ("partners_intervention_signed_pd", "Signed PD/SSFA", "intervention_signed_pd", 0, ["pmp"]),
+    ("partners_intervention_activation_letter", "PD Activation Letter", "activation_letter", 0, ["pmp"]),
+    ("partners_intervention_termination_doc", "PD Termination Document", "termination_doc", 0, ["pmp"]),
+    ("partners_intervention_amendment_signed", "PD/SSFA Amendment", "intervention_amendment_signed", 0, ["pmp"]),
+    ("partners_intervention_attachment", "Intervention Attachment", "intervention_attachment", 0, ["pmp"]),
+    ("partners_agreement_termination_doc", "Termination document for PCAs", "termination_doc", 0, ["pmp"]),
+    ("partners_intervention_amendment_internal_prc_review", "Internal PRC Review", "internal_prc_review", 0, ["pmp"]),
+    ("t2f_travel_attachment", "Travel Attachment", "t2f_travel_attachment", 0, ["t2f"]),
 ]
 
 
@@ -34,13 +36,14 @@ class Command(BaseCommand):
 
     def run(self):
         logger.info('Initialization for %s' % connection.schema_name)
-        for code, label, name, order in FILE_TYPES_MAPPING:
+        for code, label, name, order, group in FILE_TYPES_MAPPING:
             FileType.objects.update_or_create(
                 code=code,
                 defaults={
                     "label": label,
                     "name": name,
                     "order": order,
+                    "group": group,
                 }
             )
 

--- a/src/etools/applications/partners/serializers/attachments.py
+++ b/src/etools/applications/partners/serializers/attachments.py
@@ -1,0 +1,12 @@
+from rest_framework import serializers
+from unicef_attachments.models import FileType
+
+
+class PMPAttachmentFileTypeSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = FileType
+        fields = [
+            'id',
+            'name',
+            'label',
+        ]

--- a/src/etools/applications/partners/tests/test_api_attachments.py
+++ b/src/etools/applications/partners/tests/test_api_attachments.py
@@ -1,0 +1,25 @@
+from django.core.management import call_command
+from django.urls import reverse
+
+from rest_framework import status
+from unicef_attachments.models import FileType
+
+from etools.applications.core.tests.cases import BaseTenantTestCase
+from etools.applications.users.tests.factories import UserFactory
+
+
+class TestPMPAttachmentFileTypeView(BaseTenantTestCase):
+    def setUp(self):
+        super().setUp()
+        call_command("init-attachment-file-types")
+        self.user = UserFactory(is_staff=True)
+
+    def test_get(self):
+        file_type_qs = FileType.objects.group_by("pmp")
+        response = self.forced_auth_req(
+            "get",
+            reverse('partners_api:attachment-types'),
+            user=self.user,
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data), file_type_qs.count())

--- a/src/etools/applications/partners/urls_v2.py
+++ b/src/etools/applications/partners/urls_v2.py
@@ -242,7 +242,8 @@ urlpatterns = (
         name='dropdown-static-list'),
     url(r'^dropdowns/pmp/$',
         view=PMPDropdownsListApiView.as_view(http_method_names=['get']), name='dropdown-pmp-list'),
-    url(r'^attachment-types/$',
+    url(
+        r'^attachment-types/$',
         view=PMPAttachmentFileTypeView.as_view(http_method_names=['get']),
         name='attachment-types',
     ),

--- a/src/etools/applications/partners/urls_v2.py
+++ b/src/etools/applications/partners/urls_v2.py
@@ -56,7 +56,11 @@ from etools.applications.partners.views.partner_organization_v2 import (
     PlannedEngagementAPIView,
 )
 from etools.applications.partners.views.v1 import PCAPDFView
-from etools.applications.partners.views.v2 import PMPDropdownsListApiView, PMPStaticDropdownsListAPIView
+from etools.applications.partners.views.v2 import (
+    PMPAttachmentFileTypeView,
+    PMPDropdownsListApiView,
+    PMPStaticDropdownsListAPIView,
+)
 
 # http://www.django-rest-framework.org/api-guide/format-suffixes/
 
@@ -238,5 +242,9 @@ urlpatterns = (
         name='dropdown-static-list'),
     url(r'^dropdowns/pmp/$',
         view=PMPDropdownsListApiView.as_view(http_method_names=['get']), name='dropdown-pmp-list'),
+    url(r'^attachment-types/$',
+        view=PMPAttachmentFileTypeView.as_view(http_method_names=['get']),
+        name='attachment-types',
+    ),
 )
 urlpatterns = format_suffix_patterns(urlpatterns, allowed=['json', 'csv'])

--- a/src/etools/applications/partners/views/v2.py
+++ b/src/etools/applications/partners/views/v2.py
@@ -7,7 +7,7 @@ from django.db.models.functions import Concat
 
 from model_utils import Choices
 from rest_framework import status
-from rest_framework.generics import RetrieveUpdateDestroyAPIView
+from rest_framework.generics import ListAPIView, RetrieveUpdateDestroyAPIView
 from rest_framework.permissions import IsAdminUser, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -30,6 +30,7 @@ from etools.applications.partners.models import (
     PartnerType,
 )
 from etools.applications.partners.permissions import PartnershipManagerPermission
+from etools.applications.partners.serializers.attachments import PMPAttachmentFileTypeSerializer
 from etools.applications.partners.serializers.partner_organization_v2 import (
     PartnerStaffMemberCreateUpdateSerializer,
     PartnerStaffMemberDetailSerializer,
@@ -262,3 +263,9 @@ class PartnershipDashboardAPIView(APIView):
             if result['active_count'] and result['expire_in_two_months_count'] else "0%"
 
         return Response(result, status=status.HTTP_200_OK)
+
+
+class PMPAttachmentFileTypeView(ListAPIView):
+    permission_classes = (IsAdminUser,)
+    serializer_class = PMPAttachmentFileTypeSerializer
+    queryset = AttachmentFileType.objects.group_by("pmp")


### PR DESCRIPTION
Returns a list of file types available for PMP

Does require that we have the attachment file types updated. Normally the PMP attachments don't require a file type attachment, as there is a direct relation to attachment model via CodedGenericRelation, as there is a single attachment for them

Need to run `./manage.py init-attachment-file-types`