### PR TITLE
[ePD] InterventionBudget data migration tweak

### DIFF
--- a/src/etools/applications/partners/migrations/0061_auto_20200914_0758.py
+++ b/src/etools/applications/partners/migrations/0061_auto_20200914_0758.py
@@ -13,6 +13,7 @@ def create_budgets(apps, schema_editor):
             intervention=i,
             defaults={
                 "total": 0,
+                "total_local": 0,
             }
         )
         InterventionManagementBudget.objects.get_or_create(intervention=i)


### PR DESCRIPTION
Missed that `total_local` field does not have a default value either.