### PR TITLE
[ePD] Update intervention user fields to use MinimalUserSerializer

### DIFF
--- a/src/etools/applications/partners/serializers/interventions_v3.py
+++ b/src/etools/applications/partners/serializers/interventions_v3.py
@@ -26,6 +26,7 @@ from etools.applications.partners.serializers.interventions_v2 import (
 )
 from etools.applications.partners.utils import get_quarters_range
 from etools.applications.reports.serializers.v2 import InterventionTimeFrameSerializer
+from etools.applications.users.serializers_v3 import MinimalUserSerializer
 
 
 class InterventionRiskSerializer(serializers.ModelSerializer):
@@ -94,6 +95,7 @@ class InterventionDetailSerializer(serializers.ModelSerializer):
     amendments = InterventionAmendmentCUSerializer(many=True, read_only=True, required=False)
     attachments = InterventionAttachmentSerializer(many=True, read_only=True, required=False)
     available_actions = serializers.SerializerMethodField()
+    budget_owner = MinimalUserSerializer()
     status_list = serializers.SerializerMethodField()
     cluster_names = serializers.SerializerMethodField()
     days_from_review_to_signed = serializers.CharField(read_only=True)
@@ -129,6 +131,8 @@ class InterventionDetailSerializer(serializers.ModelSerializer):
     quarters = InterventionTimeFrameSerializer(many=True, read_only=True)
     supply_items = InterventionSupplyItemSerializer(many=True, read_only=True)
     management_budgets = InterventionManagementBudgetSerializer(read_only=True)
+    unicef_signatory = MinimalUserSerializer()
+    unicef_focal_points = MinimalUserSerializer(many=True)
 
     def get_location_p_codes(self, obj):
         return [location.p_code for location in obj.flat_locations.all()]

--- a/src/etools/applications/partners/tests/test_v3_interventions.py
+++ b/src/etools/applications/partners/tests/test_v3_interventions.py
@@ -98,6 +98,15 @@ class BaseInterventionTestCase(BaseTenantTestCase):
             partner=self.partner,
             signed_by_unicef_date=datetime.date.today(),
         )
+        self.user_serialized = {
+            "id": self.user.pk,
+            "name": self.user.get_full_name(),
+            "first_name": self.user.first_name,
+            "middle_name": self.user.middle_name,
+            "last_name": self.user.last_name,
+            "username": self.user.username,
+            "email": self.user.email,
+        }
 
 
 class TestList(BaseInterventionTestCase):
@@ -179,7 +188,7 @@ class TestList(BaseInterventionTestCase):
 
 class TestDetail(BaseInterventionTestCase):
     def test_get(self):
-        intervention = InterventionFactory()
+        intervention = InterventionFactory(unicef_signatory=self.user)
         frs = FundsReservationHeaderFactory(
             intervention=intervention,
             currency='USD',
@@ -205,6 +214,7 @@ class TestDetail(BaseInterventionTestCase):
         data = response.data
         self.assertEqual(data["id"], intervention.pk)
         self.assertEqual(data["result_links"][0]["total"], 30)
+        self.assertEqual(data["unicef_signatory"], self.user_serialized)
 
 
 class TestCreate(BaseInterventionTestCase):
@@ -231,7 +241,7 @@ class TestCreate(BaseInterventionTestCase):
         self.assertTrue(i.humanitarian_flag)
         self.assertTrue(data.get("humanitarian_flag"))
         self.assertEqual(data.get("cfei_number"), "321")
-        self.assertEqual(data.get("budget_owner"), self.user.pk)
+        self.assertEqual(data.get("budget_owner"), self.user_serialized)
 
     def test_add_intervention_by_partner_member(self):
         partner_user = UserFactory(is_staff=False, groups__data=[])


### PR DESCRIPTION
[ch23136]

Did not modify the fields `requesting_officer`, and `approving_officer` on Assessment model, not sure if we want those changed as well?

