### PR TITLE
[ePD] Residual 'Unassociated to CP Output' after Partner user adds and then deletes a PD output

### DIFF
--- a/src/etools/applications/partners/tests/test_v3_intervention_lower_results.py
+++ b/src/etools/applications/partners/tests/test_v3_intervention_lower_results.py
@@ -267,6 +267,19 @@ class TestInterventionLowerResultsDetailView(TestInterventionLowerResultsViewBas
         self.assertNotEqual(result.result_link, self.result_link)
         self.assertEqual(result.result_link.cp_output, None)
 
+    def test_delete_unassociated_pd_output(self):
+        result_link = InterventionResultLinkFactory(intervention=self.intervention, cp_output=None)
+        result = LowerResultFactory(result_link=result_link)
+        InterventionActivityFactory(result=result, unicef_cash=10, cso_cash=20)
+        response = self.forced_auth_req(
+            'delete',
+            reverse('partners:intervention-pd-output-detail', args=[self.intervention.pk, result.pk]),
+            self.user,
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+        self.assertFalse(InterventionResultLink.objects.filter(pk=result_link.pk).exists())
+
     # permissions are common with list view and were explicitly checked in corresponding api test case
 
     def test_associate_output_as_partner(self):

--- a/src/etools/applications/partners/views/interventions_v3.py
+++ b/src/etools/applications/partners/views/interventions_v3.py
@@ -228,7 +228,12 @@ class InterventionPDOutputsListCreateView(InterventionPDOutputsViewMixin, ListCr
 
 
 class InterventionPDOutputsDetailUpdateView(InterventionPDOutputsViewMixin, RetrieveUpdateDestroyAPIView):
-    pass
+    def perform_destroy(self, instance):
+        # do cleanup if pd output is still not associated to cp output
+        result_link = instance.result_link
+        instance.delete()
+        if result_link.cp_output is None:
+            result_link.delete()
 
 
 class PMPInterventionManagementBudgetRetrieveUpdateView(

--- a/src/etools/applications/reports/views/v2.py
+++ b/src/etools/applications/reports/views/v2.py
@@ -224,7 +224,13 @@ class LowerResultsDeleteView(DestroyAPIView):
             request.user in lower_result.result_link.intervention.unicef_focal_points.all() or \
             request.user.groups.filter(name__in=['Partnership Manager',
                                                  SENIOR_MANAGEMENT_GROUP]).exists():
+
+            # do cleanup if pd output is still not associated to cp output
+            result_link = lower_result.result_link
             lower_result.delete()
+            if result_link.cp_output is None:
+                result_link.delete()
+
             return Response(status=status.HTTP_204_NO_CONTENT)
         else:
             raise ValidationError("You do not have permissions to delete a lower result")


### PR DESCRIPTION
[ch24144]