### PR TITLE
[PMP] [ch26828 - 1] Disallow similar pairs of intervention + cp output for result links

### DIFF
--- a/src/etools/applications/partners/serializers/interventions_v2.py
+++ b/src/etools/applications/partners/serializers/interventions_v2.py
@@ -365,6 +365,13 @@ class InterventionResultLinkSimpleCUSerializer(serializers.ModelSerializer):
     class Meta:
         model = InterventionResultLink
         fields = "__all__"
+        validators = [
+            UniqueTogetherValidator(
+                queryset=InterventionResultLink.objects.all(),
+                fields=["intervention", "cp_output"],
+                message=_("Invalid CP Output provided.")
+            )
+        ]
 
 
 class InterventionResultCUSerializer(serializers.ModelSerializer):

--- a/src/etools/applications/partners/tests/test_api_interventions.py
+++ b/src/etools/applications/partners/tests/test_api_interventions.py
@@ -948,6 +948,7 @@ class TestAPIInterventionResultLinkUpdateView(BaseTenantTestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
         self.assertEqual(response.data['non_field_errors'][0], "Invalid CP Output provided.")
 
+
 class TestAPIInterventionResultLinkDeleteView(BaseTenantTestCase):
     """Exercise the delete view for InterventionResultLinkUpdateView"""
     @classmethod

--- a/src/etools/applications/partners/tests/test_api_interventions.py
+++ b/src/etools/applications/partners/tests/test_api_interventions.py
@@ -813,6 +813,15 @@ class TestAPIInterventionResultLinkCreateView(BaseTenantTestCase):
         response = self._make_request(user)
         self.assertResponseFundamentals(response)
 
+    def test_duplicates_not_allowed(self):
+        user = UserFactory()
+        _add_user_to_partnership_manager_group(user)
+        response = self._make_request(user)
+        self.assertResponseFundamentals(response)
+        response = self._make_request(user)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data['non_field_errors'][0], "Invalid CP Output provided.")
+
 
 class TestAPIInterventionResultLinkRetrieveView(BaseTenantTestCase):
     """Exercise the retrieve view for InterventionResultLinkUpdateView"""
@@ -928,6 +937,16 @@ class TestAPIInterventionResultLinkUpdateView(BaseTenantTestCase):
         response = self._make_request(user)
         self.assertResponseFundamentals(response)
 
+    def test_duplicates_not_allowed(self):
+        user = UserFactory()
+        _add_user_to_partnership_manager_group(user)
+        InterventionResultLinkFactory(
+            intervention=self.intervention_result_link.intervention,
+            cp_output=self.new_cp_output,
+        )
+        response = self._make_request(user)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST, response.data)
+        self.assertEqual(response.data['non_field_errors'][0], "Invalid CP Output provided.")
 
 class TestAPIInterventionResultLinkDeleteView(BaseTenantTestCase):
     """Exercise the delete view for InterventionResultLinkUpdateView"""


### PR DESCRIPTION
Story details: https://app.shortcut.com/unicefetools/story/26828