### PR TITLE
[ePD] Non Focal Point UNICEF user permission issues

### DIFF
--- a/src/etools/applications/partners/serializers/interventions_v3.py
+++ b/src/etools/applications/partners/serializers/interventions_v3.py
@@ -395,8 +395,8 @@ class InterventionDetailSerializer(serializers.ModelSerializer):
         ]
         user = self.context['request'].user
 
-        # Partnership Manager
-        if self._is_partnership_manager():
+        # focal point or budget owner
+        if self._is_unicef_focal_point(obj, user) or obj.budget_owner == user:
             # amendments should be deleted instead of moving to cancelled/terminated
             if not obj.in_amendment:
                 if obj.status in [obj.SIGNED, obj.ACTIVE, obj.IMPLEMENTED, obj.SUSPENDED]:
@@ -442,7 +442,7 @@ class InterventionDetailSerializer(serializers.ModelSerializer):
                     available_actions.append("review")
 
             # any unicef focal point user
-            if user in obj.unicef_focal_points.all():
+            if user in obj.unicef_focal_points.all() or obj.budget_owner == user:
                 if not obj.partner_accepted:
                     available_actions.append("send_to_partner")
                 available_actions.append("cancel")

--- a/src/etools/applications/partners/tests/test_api_amendments.py
+++ b/src/etools/applications/partners/tests/test_api_amendments.py
@@ -445,3 +445,34 @@ class TestInterventionAmendmentDeleteView(BaseTenantTestCase):
             user=self.unicef_staff,
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_delete_active(self):
+        self.intervention.status = 'active'
+        self.intervention.save()
+        response = self.forced_auth_req(
+            'delete',
+            self.url,
+            user=self.unicef_staff,
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_delete_active_focal_point(self):
+        self.intervention.status = 'active'
+        self.intervention.save()
+        self.intervention.unicef_focal_points.add(self.unicef_staff)
+        response = self.forced_auth_req(
+            'delete',
+            self.url,
+            user=self.unicef_staff,
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
+
+    def test_delete_active_partnership_manager(self):
+        self.intervention.status = 'active'
+        self.intervention.save()
+        response = self.forced_auth_req(
+            'delete',
+            self.url,
+            user=UserFactory(is_staff=True, groups__data=[UNICEF_USER, PARTNERSHIP_MANAGER_GROUP]),
+        )
+        self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)

--- a/src/etools/applications/partners/tests/test_v3_interventions.py
+++ b/src/etools/applications/partners/tests/test_v3_interventions.py
@@ -459,7 +459,7 @@ class TestDetail(BaseInterventionTestCase):
         [InterventionManagementBudgetItemFactory(budget=self.intervention.management_budgets) for _i in range(10)]
 
         # there is a lot of queries, but no duplicates caused by budget items
-        with self.assertNumQueries(48):
+        with self.assertNumQueries(47):
             response = self.forced_auth_req(
                 "get",
                 reverse('pmp_v3:intervention-detail', args=[self.intervention.pk]),

--- a/src/etools/applications/partners/tests/test_v3_serializers_intervention.py
+++ b/src/etools/applications/partners/tests/test_v3_serializers_intervention.py
@@ -40,7 +40,7 @@ class TestInterventionDetailSerializer(BaseTenantTestCase):
         self.assertEqual(pd.status, pd.SIGNED)
         self.assertEqual(
             sorted(self.unicef_serializer.get_available_actions(pd)),
-            self.default_actions,
+            self.default_actions + ['suspend', 'terminate'],
         )
         self.assertEqual(
             sorted(self.partner_serializer.get_available_actions(pd)),
@@ -89,7 +89,7 @@ class TestInterventionDetailSerializer(BaseTenantTestCase):
         pd = InterventionFactory(budget_owner=self.unicef_user)
         self.assertEqual(pd.status, pd.DRAFT)
         available_actions = self.unicef_serializer.get_available_actions(pd)
-        expected_actions = self.default_actions + ["accept", "accept_on_behalf_of_partner", "cancel"]
+        expected_actions = self.default_actions + ["accept", "send_to_partner", "accept_on_behalf_of_partner", "cancel"]
         self.assertEqual(sorted(available_actions), sorted(expected_actions))
 
     def test_available_actions_management(self):
@@ -117,7 +117,7 @@ class TestInterventionDetailSerializer(BaseTenantTestCase):
         )
         self.assertEqual(pd.status, pd.SUSPENDED)
         available_actions = self.unicef_serializer.get_available_actions(pd)
-        expected_actions = self.default_actions + ["terminate", "unsuspend"]
+        expected_actions = self.default_actions
         self.assertEqual(sorted(available_actions), sorted(expected_actions))
 
     def test_available_actions_management_terminate(self):
@@ -127,7 +127,7 @@ class TestInterventionDetailSerializer(BaseTenantTestCase):
         )
         self.assertEqual(pd.status, pd.ACTIVE)
         available_actions = self.unicef_serializer.get_available_actions(pd)
-        expected_actions = self.default_actions + ["suspend", "terminate"]
+        expected_actions = self.default_actions
         self.assertEqual(sorted(available_actions), sorted(expected_actions))
 
         # not available if closed

--- a/src/etools/applications/partners/views/interventions_v2.py
+++ b/src/etools/applications/partners/views/interventions_v2.py
@@ -42,6 +42,7 @@ from etools.applications.partners.models import (
     InterventionResultLink,
 )
 from etools.applications.partners.permissions import (
+    PARTNERSHIP_MANAGER_GROUP,
     PartnershipManagerPermission,
     PartnershipManagerRepPermission,
     SENIOR_MANAGEMENT_GROUP,
@@ -532,7 +533,7 @@ class InterventionAmendmentDeleteView(DestroyAPIView):
 
         if intervention_amendment.intervention.status in [Intervention.DRAFT] or \
             request.user in intervention_amendment.intervention.unicef_focal_points.all() or \
-            request.user.groups.filter(name__in=['Partnership Manager',
+            request.user.groups.filter(name__in=[PARTNERSHIP_MANAGER_GROUP,
                                                  SENIOR_MANAGEMENT_GROUP]).exists():
             intervention_amendment.delete()
             return Response(status=status.HTTP_204_NO_CONTENT)

--- a/src/etools/applications/partners/views/interventions_v3_actions.py
+++ b/src/etools/applications/partners/views/interventions_v3_actions.py
@@ -519,6 +519,10 @@ class PMPInterventionSendToPartnerView(PMPInterventionActionView):
         pd = self.get_object()
         if not pd.unicef_court:
             raise ValidationError("PD is currently with Partner")
+
+        if self.request.user not in pd.unicef_focal_points.all() and self.request.user != pd.budget_owner:
+            raise ValidationError("Only focal points or budget owners can send to partner")
+
         request.data.clear()
         request.data.update({"unicef_court": False})
         if not pd.date_sent_to_partner:
@@ -550,6 +554,10 @@ class PMPInterventionSendToUNICEFView(PMPInterventionActionView):
         pd = self.get_object()
         if pd.unicef_court:
             raise ValidationError("PD is currently with UNICEF")
+
+        if not self.is_partner_focal_point(pd):
+            raise ValidationError("Only partner focal points can send to UNICEF")
+
         request.data.clear()
         request.data.update({"unicef_court": True})
         if not pd.submission_date:

--- a/src/etools/applications/partners/views/interventions_v3_actions.py
+++ b/src/etools/applications/partners/views/interventions_v3_actions.py
@@ -297,6 +297,10 @@ class PMPInterventionCancelView(PMPInterventionActionView):
         pd = self.get_object()
         if pd.status == Intervention.CANCELLED:
             raise ValidationError("PD has already been cancelled.")
+
+        if self.request.user not in pd.unicef_focal_points.all() and self.request.user != pd.budget_owner:
+            raise ValidationError("Only focal points or budget owners can cancel")
+
         request.data.update({"status": Intervention.CANCELLED})
 
         response = super().update(request, *args, **kwargs)
@@ -329,6 +333,9 @@ class PMPInterventionTerminateView(PMPInterventionActionView):
         pd = self.get_object()
         if pd.status == Intervention.TERMINATED:
             raise ValidationError("PD has already been terminated.")
+
+        if self.request.user not in pd.unicef_focal_points.all() and self.request.user != pd.budget_owner:
+            raise ValidationError("Only focal points or budget owners can terminate")
 
         # override status as terminated
         request.data.update({"status": Intervention.TERMINATED})
@@ -363,6 +370,9 @@ class PMPInterventionSuspendView(PMPInterventionActionView):
         if pd.status == Intervention.SUSPENDED:
             raise ValidationError("PD has already been suspended.")
 
+        if self.request.user not in pd.unicef_focal_points.all() and self.request.user != pd.budget_owner:
+            raise ValidationError("Only focal points or budget owners can suspend")
+
         # override status as suspended
         request.data.update({"status": Intervention.SUSPENDED})
         response = super().update(request, *args, **kwargs)
@@ -395,6 +405,9 @@ class PMPInterventionUnsuspendView(PMPInterventionActionView):
         pd = self.get_object()
         if pd.status != Intervention.SUSPENDED:
             raise ValidationError("PD is not suspended.")
+
+        if self.request.user not in pd.unicef_focal_points.all() and self.request.user != pd.budget_owner:
+            raise ValidationError("Only focal points or budget owners can unsuspend")
 
         # override status as active
         request.data.update({"status": Intervention.ACTIVE})


### PR DESCRIPTION
A non focal point UNICEF user should not be able to:
- delete an active amendment (where he is not focal point)
- suspend or terminate a PD (where he is not focal point)
