### PR TITLE
[ePD] 'Delete PD' not present in available_actions

### DIFF
--- a/src/etools/applications/partners/views/interventions_v2.py
+++ b/src/etools/applications/partners/views/interventions_v2.py
@@ -796,6 +796,9 @@ class InterventionDeleteView(DestroyAPIView):
         if intervention.travel_activities.count():
             raise ValidationError("Cannot delete a PD or SSFA that has Planned Trips")
 
+        if intervention.date_sent_to_partner:
+            raise ValidationError("PD has already been sent to Partner.")
+
         else:
             # get the history of this PD and make sure it wasn't manually moved back to draft before allowing deletion
             act = Activity.objects.filter(target_object_id=intervention.id,


### PR DESCRIPTION
Delete only available if it was never sent to partner. 1. date_sent_to_partner is null. 2. Snapshot model does not include any changes to the date_sent_to_partner field.