### PR TITLE
[TPM] Can't edit user in TPM, FAM

### DIFF
--- a/src/etools/applications/users/validators.py
+++ b/src/etools/applications/users/validators.py
@@ -38,7 +38,6 @@ class EmailValidator(UniqueValidator):
             message="This user already exists in the system.",
         )
 
-
     def exclude_current_instance(self, queryset, instance):
         """
         If an instance is already assigned to validator itself, prefer it.


### PR DESCRIPTION
Story details: https://app.shortcut.com/unicefetools/story/26464

fixed instance usage for EmailValidator. by design, WritableNestedChildSerializerMixin can set instance directly to validator, but only if such attribute exists