### PR TITLE
[ch28014] ePD: sentry-5965: fix 500 for not authenticated user 

### DIFF
--- a/src/etools/applications/partners/tests/test_v3_interventions.py
+++ b/src/etools/applications/partners/tests/test_v3_interventions.py
@@ -12,6 +12,7 @@ from django.urls import reverse
 from django.utils import timezone
 
 from rest_framework import status
+from rest_framework.test import APIClient
 from unicef_locations.tests.factories import LocationFactory
 from unicef_snapshot.utils import create_dict_with_relations, create_snapshot
 from waffle.utils import get_cache
@@ -354,6 +355,16 @@ class TestDetail(BaseInterventionTestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response['Content-Type'], 'application/pdf')
+
+    def test_pdf_unauthenticated_user_forbidden(self):
+        """Ensure an unauthenticated user gets the 403 forbidden"""
+        response = APIClient().get(
+            reverse(
+                'pmp_v3:intervention-detail-pdf',
+                args=[self.intervention.pk],
+            )
+        )
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
 
     def test_pdf_partner_user(self):
         staff_member = PartnerStaffFactory(partner=self.intervention.agreement.partner)

--- a/src/etools/applications/partners/views/interventions_v3.py
+++ b/src/etools/applications/partners/views/interventions_v3.py
@@ -194,7 +194,7 @@ class PMPInterventionRetrieveUpdateView(PMPInterventionMixin, InterventionDetail
 
 class PMPInterventionPDFView(PMPInterventionMixin, RetrieveAPIView):
     queryset = Intervention.objects.detail_qs().all()
-    permission_classes = (PMPInterventionPermission,)
+    permission_classes = (IsAuthenticated, PMPInterventionPermission,)
 
     def get(self, request, *args, **kwargs):
         pd = self.get_pd_or_404(self.kwargs.get("pk"))


### PR DESCRIPTION
[ch28014] 403 instead 500 for Anonymous user on /api/pmp/v3/interventions/{pk}/pdf/