### PR TITLE
Trips list: add delete permission

### DIFF
--- a/src/etools/applications/travel/serializers.py
+++ b/src/etools/applications/travel/serializers.py
@@ -88,13 +88,17 @@ class BaseTripSerializer(serializers.ModelSerializer):
         model = Trip
 
     def get_permissions(self, obj):
-        # don't provide permissions for list view
+        user = self.context['request'].user
+        # provide obj delete permissions for list view
+        # delete is available for the traveller or the travel administrator
         if self.context["view"].action == "list":
-            return []
+            return {
+                "delete": obj.traveller == user or user.groups.filter(name='Travel Administrator').exists()
+            }
 
         ps = Trip.permission_structure()
         permissions = TripPermissions(
-            self.context['request'].user,
+            user,
             obj,
             ps,
         )


### PR DESCRIPTION
[ch28881] Draft trips should be able to be deleted by the **traveler** or the **travel administrator**
For trips list, the permissions field is no longer an empty list, but contains the delete permission:  
```
"permissions": {
 "delete": true/false
}
```
@robertavram Not sure on the right approach here, let me know what you think.