### PR TITLE
[ch29637] ePD supply table upload fails

### DIFF
--- a/src/etools/applications/partners/serializers/interventions_v3.py
+++ b/src/etools/applications/partners/serializers/interventions_v3.py
@@ -1,6 +1,7 @@
 import codecs
 import csv
 import decimal
+import string
 
 from django.contrib.auth import get_user_model
 from django.db import transaction
@@ -119,6 +120,7 @@ class InterventionSupplyItemUploadSerializer(serializers.Serializer):
             codecs.iterdecode(
                 self.validated_data.get("supply_items_file"),
                 "utf-8",
+                errors='ignore'
             ),
             delimiter=",",
         )
@@ -135,11 +137,14 @@ class InterventionSupplyItemUploadSerializer(serializers.Serializer):
                 except decimal.InvalidOperation:
                     raise ValidationError(f"Unable to process row {index}, bad number provided for `Indicative Price`")
 
+                title = ''.join([x if x in string.printable else '' for x in row["Product Title"]])
+                product_no = ''.join([x if x in string.printable else '' for x in row["Product Number"]])
+
                 data.append((
-                    row["Product Title"],
+                    title,
                     quantity,
                     price,
-                    row["Product Number"],
+                    product_no,
                 ))
         return data
 

--- a/src/etools/applications/partners/tests/test_v3_interventions.py
+++ b/src/etools/applications/partners/tests/test_v3_interventions.py
@@ -1585,6 +1585,32 @@ class TestSupplyItem(BaseInterventionTestCase):
         )
         self.assertEqual(new_item.title, "First aid kit A")
 
+    def test_upload_400_max_length_exceeded(self):
+        supply_items_file = SimpleUploadedFile(
+            'my_list.csv',
+            u'''"Product Number","Product Title","Product Description","Unit of Measure",Quantity,"Indicative Price","Total Price"\n
+            S9975020,"Product Title to exceed maximum length of 150 characters **********************************************************************************************", "First aid kit A",EA,1,28,28\n
+            '''.encode('utf-8'),
+            content_type="multipart/form-data",
+        )
+        response = self.forced_auth_req(
+            "post",
+            reverse(
+                "pmp_v3:intervention-supply-item-upload",
+                args=[self.intervention.pk],
+            ),
+            data={
+                "supply_items_file": supply_items_file,
+            },
+            request_format=None,
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data['supply_items_file'],
+            'S9975020:  value too long for type character varying(150)\n',
+        )
+
 
 class TestInterventionUpdate(BaseInterventionTestCase):
     def _test_patch(self, mapping):


### PR DESCRIPTION
[ch29637] 
Csv fails when: 
1. Non printable character is present
2. Char length exceeds db max_length