### PR TITLE
[FM] Marking a question as inactive for default questions is throwing an error

### DIFF
--- a/src/etools/applications/field_monitoring/fm_settings/serializers.py
+++ b/src/etools/applications/field_monitoring/fm_settings/serializers.py
@@ -97,7 +97,7 @@ class QuestionSerializer(QuestionLightSerializer):
 
     def update(self, instance, validated_data):
         # For non-custom questions the only option we have is to modify is_active
-        custom_changes_allowed = not validated_data or validated_data.keys() == ["is_active"]
+        custom_changes_allowed = not validated_data or list(validated_data.keys()) == ["is_active"]
         if not instance.is_custom and not custom_changes_allowed:
             raise ValidationError("The system provided questions cannot be edited.")
 

--- a/src/etools/applications/field_monitoring/fm_settings/tests/test_views.py
+++ b/src/etools/applications/field_monitoring/fm_settings/tests/test_views.py
@@ -953,3 +953,28 @@ class TestQuestionsView(FMBaseTestCaseMixin, BaseTenantTestCase):
         self.assertEqual(len(response.data['options']), 3)
         self.assertTrue(question.options.filter(pk=first_option.pk).exists())
         self.assertFalse(question.options.filter(pk=second_option.pk).exists())
+
+    def test_deactivate_default_question(self):
+        question = QuestionFactory(is_custom=False, is_active=True)
+
+        response = self.forced_auth_req(
+            'patch',
+            reverse('field_monitoring_settings:questions-detail', args=[question.id, ]),
+            user=self.pme,
+            data={'is_active': False}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_change_default_question_forbidden(self):
+        question = QuestionFactory(is_custom=False, is_active=True)
+
+        response = self.forced_auth_req(
+            'patch',
+            reverse('field_monitoring_settings:questions-detail', args=[question.id, ]),
+            user=self.pme,
+            data={'text': 'some new text'}
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("The system provided questions cannot be edited.", response.data)


### PR DESCRIPTION
Story details: https://app.shortcut.com/unicefetools/story/31814