### PR TITLE
[ch31914] AMP changes and fixes

### DIFF
--- a/src/etools/applications/audit/purchase_order/admin.py
+++ b/src/etools/applications/audit/purchase_order/admin.py
@@ -62,7 +62,9 @@ class PurchaseOrderAdmin(ExtraUrlMixin, admin.ModelAdmin):
 class AuditorStaffAdmin(admin.ModelAdmin):
     list_display = ['user', 'email', 'auditor_firm', 'hidden']
     list_filter = ['auditor_firm', 'hidden']
-    search_fields = ['user__username', 'user__email', 'user__first_name', 'user__last_name', 'auditor_firm__name', ]
+    search_fields = ['user__username', 'user__email', 'user__first_name', 'user__last_name',
+                     'auditor_firm__organization__name', ]
+    autocomplete_fields = ['auditor_firm']
     readonly_fields = 'history',
     raw_id_fields = ['user', ]
 

--- a/src/etools/applications/audit/signals.py
+++ b/src/etools/applications/audit/signals.py
@@ -26,6 +26,8 @@ def staff_member_changed(sender, instance, action, reverse, pk_set, *args, **kwa
                 group=Auditor.as_group(),
                 defaults={"is_active": True}
             )
+            member.user.profile.organization = member.auditor_firm.organization
+            member.user.profile.save(update_fields=['organization'])
 
 
 @receiver(post_save, sender=EngagementActionPoint)

--- a/src/etools/applications/core/auth.py
+++ b/src/etools/applications/core/auth.py
@@ -80,13 +80,16 @@ def user_details(strategy, details, backend, user=None, *args, **kwargs):
             country = Country.objects.get(name='UAT')
 
         if details.get("idp") == "UNICEF Azure AD" and "UNICEF User" not in user_groups:
+            unicef_org = Organization.objects.get(name='UNICEF')
             Realm.objects.create(
                 user=user,
                 country=country,
-                organization=Organization.objects.get(name='UNICEF'),
+                organization=unicef_org,
                 group=Group.objects.get(name='UNICEF User'))
             user.is_staff = True
             user.save(update_fields=['is_staff'])
+            user.profile.organization = unicef_org
+            user.profile.save(update_fields=['organization'])
 
         if not user.profile.country:
             user.profile.country = country

--- a/src/etools/applications/field_monitoring/planning/models.py
+++ b/src/etools/applications/field_monitoring/planning/models.py
@@ -338,12 +338,10 @@ class MonitoringActivity(
         # if rejected send notice
         if old_instance and old_instance.status == self.STATUSES.assigned:
             email_template = "fm/activity/reject"
-            # TODO REALMS: check logic here wrto organization
             recipients = User.objects\
                 .prefetch_related('realms')\
                 .filter(realms__group=PME.as_group(),
                         realms__country=connection.tenant,
-                        # realms__organization=old_instance.tpm_partner.organization
                         )
             for recipient in recipients:
                 self._send_email(

--- a/src/etools/applications/partners/models.py
+++ b/src/etools/applications/partners/models.py
@@ -1004,12 +1004,14 @@ class PartnerStaffMember(TimeStampedModel):
             if self.active:
                 # staff is activated
                 self.user.profile.country = connection.tenant
-                self.user.profile.save(update_fields=['country'])
+                self.user.profile.organization = self.partner.organization
+                self.user.profile.save(update_fields=['country', 'organization'])
             else:
                 # staff is deactivated
                 # using first() here because public schema unavailable during testing
                 self.user.profile.country = Country.objects.filter(schema_name=get_public_schema_name()).first()
-                self.user.profile.save(update_fields=['country'])
+                self.user.profile.organization = None
+                self.user.profile.save(update_fields=['country', 'organization'])
             # create or update (activate/deactivate) corresponding Realm
             Realm.objects.update_or_create(
                 user=self.user,

--- a/src/etools/applications/tpm/signals.py
+++ b/src/etools/applications/tpm/signals.py
@@ -36,3 +36,5 @@ def tpmvisit_save_receiver(instance, created, **kwargs):
                 organization=instance.tpm_partner.organization,
                 group=ThirdPartyMonitor.as_group()
             )
+            staff.user.profile.organization = instance.tpm_partner.organization
+            staff.user.profile.save(update_fields=['organization'])

--- a/src/etools/applications/tpm/tpmpartners/admin.py
+++ b/src/etools/applications/tpm/tpmpartners/admin.py
@@ -37,7 +37,8 @@ class TPMPartnerStaffMemberAdmin(admin.ModelAdmin):
     readonly_fields = 'history',
     list_filter = ['receive_tpm_notifications', 'user__is_active', 'tpm_partner']
     search_fields = ['user__email', 'user__first_name', 'user__last_name', 'user__profile__phone_number',
-                     'tpm_partner__name']
+                     'tpm_partner__organization__name']
+    autocomplete_fields = ['tpm_partner']
     raw_id_fields = ('user',)
 
     def email(self, obj):

--- a/src/etools/applications/tpm/tpmpartners/synchronizers.py
+++ b/src/etools/applications/tpm/tpmpartners/synchronizers.py
@@ -2,6 +2,7 @@ import logging
 
 from etools.applications.organizations.models import Organization, OrganizationType
 from etools.applications.tpm.tpmpartners.models import TPMPartner
+from etools.applications.users.models import Country, Realm, User
 from etools.applications.vision.synchronizers import VisionDataTenantSynchronizer
 
 logger = logging.getLogger(__name__)
@@ -51,7 +52,9 @@ class TPMPartnerSynchronizer(VisionDataTenantSynchronizer):
                 'deleted_flag': True if partner['MARKED_FOR_DELETION'] else False,
                 'hidden': True if partner['POSTING_BLOCK'] or partner['MARKED_FOR_DELETION'] else False,
             }
-            TPMPartner.objects.update_or_create(organization=organization, defaults=defaults)
+            partner, _ = TPMPartner.objects.update_or_create(organization=organization, defaults=defaults)
+            if partner.deleted_flag:
+                self.deactivate_staff_members(partner)
             processed = 1
 
         except Exception:
@@ -80,3 +83,18 @@ class TPMPartnerSynchronizer(VisionDataTenantSynchronizer):
             processed += self._partner_save(partner)
 
         return processed
+
+    @staticmethod
+    def deactivate_staff_members(partner):
+        staff_members = partner.staff_members.all()
+        # deactivate the users
+        users_deactivate = User.objects.filter(tpmpartners_tpmpartnerstaffmember__in=staff_members)
+        users_deactivate.update(is_active=False)
+        try:
+            country = Country.objects.get(name=partner.country)
+            Realm.objects\
+                .filter(user__in=users_deactivate, country=country, organization=partner.organization)\
+                .update(is_active=False)
+        except Country.DoesNotExist:
+            logging.error(f"No country with name {partner.country} exists. "
+                          f"Cannot deactivate realms for users.")

--- a/src/etools/applications/tpm/views.py
+++ b/src/etools/applications/tpm/views.py
@@ -224,13 +224,14 @@ class TPMStaffMembersViewSet(
         instance = serializer.save(tpm_partner=self.get_parent_object(), **kwargs)
         if not instance.user.profile.country:
             instance.user.profile.country = self.request.user.profile.country
+        instance.user.profile.organization = instance.tpm_partner.organization
         Realm.objects.update_or_create(
             user=instance.user,
             country=instance.user.profile.country,
             organization=instance.tpm_partner.organization,
             group=ThirdPartyMonitor.as_group()
         )
-        instance.user.profile.save()
+        instance.user.profile.save(update_fields=['country', 'organization'])
 
     @action(detail=False, methods=['get'], url_path='export', renderer_classes=(TPMPartnerContactsCSVRenderer,))
     def export(self, request, *args, **kwargs):

--- a/src/etools/applications/users/admin.py
+++ b/src/etools/applications/users/admin.py
@@ -210,7 +210,7 @@ class UserAdminPlus(ExtraUrlMixin, UserAdmin):
     list_filter = ('is_staff', 'is_superuser', 'is_active', 'old_groups')
     filter_horizontal = ('old_groups', 'user_permissions',)
     inlines = [ProfileInline, RealmInline]
-    readonly_fields = ('date_joined',)
+    readonly_fields = ('last_login', 'date_joined',)
 
     list_display = [
         'email',

--- a/src/etools/applications/users/mixins.py
+++ b/src/etools/applications/users/mixins.py
@@ -13,7 +13,7 @@ class GroupEditPermissionMixin:
         "UNICEF Audit Focal Point": ["Auditor"],
     }
 
-    CAN_ADD_USER = ["IP Admin", "IP Authorized Officer"]
+    CAN_ADD_USER = ["IP Admin", "IP Authorized Officer", "Partnership Manager"]
 
     def get_user_allowed_groups(self, user=None):
         groups_allowed_editing = []

--- a/src/etools/applications/users/models.py
+++ b/src/etools/applications/users/models.py
@@ -9,6 +9,7 @@ from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import connection, models
+from django.db.models import Q
 from django.db.models.signals import post_save
 from django.urls import reverse
 from django.utils.functional import cached_property
@@ -193,7 +194,9 @@ class User(TimeStampedModel, AbstractBaseUser, PermissionsMixin):
     @property
     def groups(self):
         current_country_realms = self.realms.filter(
-            country=connection.tenant, organization=self.profile.organization, is_active=True)
+            Q(organization=self.profile.organization) |
+            Q(organization__vendor_number='UNICEF'),
+            country=connection.tenant, is_active=True)
         return Group.objects.filter(realms__in=current_country_realms).distinct()
 
     def get_groups_for_organization_id(self, organization_id):

--- a/src/etools/applications/users/models.py
+++ b/src/etools/applications/users/models.py
@@ -510,7 +510,6 @@ class UserProfile(models.Model):
                 return False
 
         if new_country and new_country != sender.profile.country:
-            # TODO REALMS: add country realm
             # sender.profile.countries_available.add(new_country)
             sender.profile.country = new_country
             sender.profile.save()

--- a/src/etools/applications/users/models.py
+++ b/src/etools/applications/users/models.py
@@ -3,15 +3,7 @@ from decimal import Decimal
 from typing import TYPE_CHECKING
 
 from django.conf import settings
-from django.contrib.auth.models import (
-    _user_get_permissions,
-    _user_has_module_perms,
-    _user_has_perm,
-    AbstractBaseUser,
-    Group,
-    Permission,
-    UserManager,
-)
+from django.contrib.auth.models import _user_get_permissions, AbstractBaseUser, Group, Permission, UserManager
 from django.contrib.contenttypes.fields import GenericRelation
 from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
@@ -95,12 +87,10 @@ class PermissionsMixin(models.Model):
         assumed to have permission in general. If an object is provided, check
         permissions for that object.
         """
-        # Active superusers have all permissions.
-        if self.is_active and self.is_superuser:
+        # Active superusers and staff have all permissions.
+        if self.is_active and (self.is_superuser or self.is_staff):
             return True
-
-        # Otherwise we need to check the backends.
-        return _user_has_perm(self, perm, obj)
+        return False
 
     def has_perms(self, perm_list, obj=None):
         """
@@ -114,11 +104,10 @@ class PermissionsMixin(models.Model):
         Return True if the user has any permissions in the given app label.
         Use similar logic as has_perm(), above.
         """
-        # Active superusers have all permissions.
-        if self.is_active and self.is_superuser:
+        # Active superusers and staff have all permissions.
+        if self.is_active and (self.is_superuser or self.is_staff):
             return True
-
-        return _user_has_module_perms(self, app_label)
+        return False
 
 
 class UsersManager(UserManager):

--- a/src/etools/applications/users/models.py
+++ b/src/etools/applications/users/models.py
@@ -9,7 +9,6 @@ from django.core.exceptions import ValidationError
 from django.core.mail import send_mail
 from django.core.validators import MaxValueValidator, MinValueValidator
 from django.db import connection, models
-from django.db.models import Q
 from django.db.models.signals import post_save
 from django.urls import reverse
 from django.utils.functional import cached_property
@@ -194,9 +193,7 @@ class User(TimeStampedModel, AbstractBaseUser, PermissionsMixin):
     @property
     def groups(self):
         current_country_realms = self.realms.filter(
-            Q(organization=self.profile.organization) |
-            Q(organization__vendor_number='UNICEF'),
-            country=connection.tenant, is_active=True)
+            country=connection.tenant, organization=self.profile.organization, is_active=True)
         return Group.objects.filter(realms__in=current_country_realms).distinct()
 
     def get_groups_for_organization_id(self, organization_id):

--- a/src/etools/applications/users/notifications/amp_role-update.py
+++ b/src/etools/applications/users/notifications/amp_role-update.py
@@ -1,0 +1,38 @@
+from unicef_notification.utils import strip_text
+
+name = 'users/amp/role-update'
+defaults = {
+    'description': 'User role update',
+    'subject': '[eTools] User role update for {{ user_full_name }}',
+
+    'content': strip_text("""
+    Dear {{  user_full_name }},
+
+    Your role in UNICEF's Access Management Portal has been updated.
+    You now have access to:
+    {% for realm in active_realms %}
+        {{ realm.organization__name }} organization in {{ realm.country__name }} with the role of {{ realm.group__name }} <br/>
+    {% endfor %}
+    Kind regards,
+    UNICEF
+    Please note that this is an automatically generated email. Responses are not monitored and cannot be replied to.</p>
+    """),
+
+    'html_content': """
+    {% extends "email-templates/base" %}
+
+    {% block content %}
+    Dear {{ user_full_name }}, <br/>
+
+    Your role in UNICEF's Access Management Portal has been updated.
+    You now have access to: <br/><br/>
+    {% for realm in active_realms %}
+    <b>{{ realm.organization__name }}</b> organization in <b>{{ realm.country__name }}</b> with the role of <b>{{ realm.group__name }}</b> <br/><br/>
+    {% endfor %}
+    <br/>
+    Kind regards,</br>
+    UNICEF<br/>
+    <p>Please note that this is an automatically generated email. Responses are not monitored and cannot be replied to.</p>
+    {% endblock content %}
+    """
+}

--- a/src/etools/applications/users/notifications/amp_role-update.py
+++ b/src/etools/applications/users/notifications/amp_role-update.py
@@ -11,18 +11,18 @@ defaults = {
     Your role in UNICEF's Access Management Portal has been updated.
     You now have access to:
     {% for realm in active_realms %}
-        {{ realm.organization__name }} organization in {{ realm.country__name }} with the role of {{ realm.group__name }} <br/>
+        {{ realm.organization__name }} organization in {{ realm.country__name }} with the role of {{ realm.group__name }}
     {% endfor %}
     Kind regards,
     UNICEF
-    Please note that this is an automatically generated email. Responses are not monitored and cannot be replied to.</p>
+    Please note that this is an automatically generated email. Responses are not monitored and cannot be replied to.
     """),
 
     'html_content': """
     {% extends "email-templates/base" %}
 
     {% block content %}
-    Dear {{ user_full_name }}, <br/>
+    Dear {{ user_full_name }}, <br/><br/>
 
     Your role in UNICEF's Access Management Portal has been updated.
     You now have access to: <br/><br/>

--- a/src/etools/applications/users/permissions.py
+++ b/src/etools/applications/users/permissions.py
@@ -22,3 +22,14 @@ class IsPartnershipManager(BasePermission):
                     group=PartnershipManager.as_group(),
                     is_active=True)\
             .exists()
+
+
+class IsActiveInRealm(BasePermission):
+    """Allows access to users who are in the current realm, despite of their groups"""
+
+    def has_permission(self, request, view):
+        return request.user.realms \
+            .filter(country=request.user.profile.country,
+                    organization=request.user.profile.organization,
+                    is_active=True) \
+            .exists()

--- a/src/etools/applications/users/serializers_v3.py
+++ b/src/etools/applications/users/serializers_v3.py
@@ -122,7 +122,8 @@ class RealmSerializer(serializers.ModelSerializer):
 
 
 class UserRealmRetrieveSerializer(serializers.ModelSerializer):
-    name = serializers.CharField(source='full_name')
+    phone_number = serializers.CharField(source='profile.phone_number')
+    job_title = serializers.CharField(source='profile.job_title')
     realms = RealmSerializer(many=True, read_only=True)
 
     class Meta:
@@ -131,8 +132,11 @@ class UserRealmRetrieveSerializer(serializers.ModelSerializer):
             'id',
             'is_active',
             'last_login',
-            'name',
+            'first_name',
+            'last_name',
             'email',
+            'phone_number',
+            'job_title',
             'realms'
         )
 

--- a/src/etools/applications/users/serializers_v3.py
+++ b/src/etools/applications/users/serializers_v3.py
@@ -205,8 +205,12 @@ class UserRealmCreateSerializer(UserRealmBaseSerializer):
 
         email = validated_data.pop('email')
         validated_data.update({"username": email})
+
         instance, _ = get_user_model().objects.get_or_create(
             email=email, defaults=validated_data)
+        if not instance.is_active:
+            instance.is_active = True
+            instance.save(update_fields=['is_active'])
 
         if job_title:
             instance.profile.job_title = job_title

--- a/src/etools/applications/users/tasks.py
+++ b/src/etools/applications/users/tasks.py
@@ -3,11 +3,11 @@ from django.contrib.auth.models import Group
 from django.db import connection, IntegrityError, transaction
 
 from celery.utils.log import get_task_logger
-from etools.config.celery import app
 
 from etools.applications.environment.notifications import send_notification_with_template
 from etools.applications.organizations.models import Organization
 from etools.applications.users.models import Country, Realm, User, UserProfile
+from etools.config.celery import app
 
 logger = get_task_logger(__name__)
 

--- a/src/etools/applications/users/views_v3.py
+++ b/src/etools/applications/users/views_v3.py
@@ -210,9 +210,9 @@ class PartnerOrganizationListView(ListAPIView):
 
         if not self.request.user.is_partnership_manager:
             return self.model.objects.none()
-
+        # returns only Partner Organizations that are not marked for deletion
         return self.model.objects\
-            .filter(partner__isnull=False, realms__country=country)\
+            .filter(partner__isnull=False, partner__deleted_flag=False, realms__country=country)\
             .distinct()
 
 
@@ -237,6 +237,8 @@ class UserRealmViewSet(
     viewsets.GenericViewSet
 ):
     model = get_user_model()
+    serializer_class = UserRealmRetrieveSerializer
+
     pagination_class = DynamicPageNumberPagination
     filter_backends = (SearchFilter, DjangoFilterBackend, OrderingFilter)
 
@@ -262,12 +264,11 @@ class UserRealmViewSet(
         return super().get_permissions()
 
     def get_serializer_class(self):
-        if self.request.method == 'GET':
-            return UserRealmRetrieveSerializer
         if self.request.method == "POST":
             return UserRealmCreateSerializer
         if self.request.method == "PATCH":
             return UserRealmUpdateSerializer
+        return super().get_serializer_class()
 
     def get_queryset(self):
         organization_id = self.request.query_params.get('organization_id')

--- a/src/etools/applications/users/views_v3.py
+++ b/src/etools/applications/users/views_v3.py
@@ -244,7 +244,7 @@ class UserRealmViewSet(
 
     search_fields = ('first_name', 'last_name', 'email', 'profile__job_title')
     filter_fields = ('is_active', )
-    ordering_fields = ('first_name', 'email', 'last_login')
+    ordering_fields = ('first_name', 'last_name', 'email', 'last_login')
 
     def get_permissions(self):
         if self.action == "list":


### PR DESCRIPTION
[ch31914] 
AMP:
1. Allow list access to users that have active realms in the current context 
2. Adding a user checks for existing user first 
3. Partnership manager role can also add a user -
4. Filter out organizations that have partners marked for deletion 
5. Users blob in list response to contain first and last name instead of name, also add profile.phone_number, job_title 
6. Update user notification: only sent on update 

Audit, Partners, TPMPartners apps :
1. Adding a staff member also sets the organization on the profile 
Azure user mapper: deactivate all realms for past country 

Authentication: Update core.user_details() to set organization on the user profile

Vision Sync: Partner, TPM Partner Synchronizer: when a partner is marked for deletion, deactivate users and all realms for that organization in that country 

Fixes for:
1. admin: error on name lookup for Audit Staff member detail view 
2. admin: staff user cannot access admin: User has no field named 'groups' error 
3. admin: last_login is read-only 