### PR TITLE
[FM] Sites are not updated when changing the country #2

### DIFF
--- a/src/etools/applications/field_monitoring/fm_settings/views.py
+++ b/src/etools/applications/field_monitoring/fm_settings/views.py
@@ -109,8 +109,10 @@ class LocationSitesViewSet(FMBaseViewSet, viewsets.ModelViewSet):
     def get_view_name(self):
         return _('Site Specific Locations')
 
-    @method_decorator(cache_control(no_cache=True))  # disable browser cache
-    @method_decorator(cache_control(public=True))  # reset cache control header to allow etags work with cache_page
+    @method_decorator(cache_control(
+        max_age=0,  # enable cache yet automatically treat all cached data as stale to request backend every time
+        public=True,  # reset cache control header to allow etags work with cache_page
+    ))
     @etag_cached('fm-sites')
     @method_decorator(cache_page(60 * 60 * 24, key_prefix=TenantSuffixedString('fm-sites')))
     def list(self, request, *args, **kwargs):

--- a/src/etools/applications/locations/views.py
+++ b/src/etools/applications/locations/views.py
@@ -18,8 +18,10 @@ def cache_key(request: Request):
 
 
 class LocationsLightViewSet(views.LocationsLightViewSet):
-    @method_decorator(cache_control(no_cache=True))  # disable browser cache
-    @method_decorator(cache_control(public=True))  # reset cache control header to allow etags work with cache_page
+    @method_decorator(cache_control(
+        max_age=0,  # enable cache yet automatically treat all cached data as stale to request backend every time
+        public=True,  # reset cache control header to allow etags work with cache_page
+    ))
     @etag_cached('locations')  # etag_cached is idempotent, so it's okay to decorate view with it twice
     @method_decorator(cache_page(60 * 60 * 24, key_prefix=TenantSuffixedString('locations')))
     def list(self, request, *args, **kwargs):
@@ -27,8 +29,10 @@ class LocationsLightViewSet(views.LocationsLightViewSet):
 
 
 class LocationsViewSet(views.LocationsViewSet):
-    @method_decorator(cache_control(no_cache=True))  # disable browser cache
-    @method_decorator(cache_control(public=True))  # reset cache control header to allow etags work with cache_page
+    @method_decorator(cache_control(
+        max_age=0,  # enable cache yet automatically treat all cached data as stale to request backend every time
+        public=True,  # reset cache control header to allow etags work with cache_page
+    ))
     @etag_cached('locations')  # etag_cached is idempotent, so it's okay to decorate view with it twice
     @method_decorator(cache_page(60 * 60 * 24, key_prefix=TenantSuffixedString('locations')))
     def list(self, request, *args, **kwargs):


### PR DESCRIPTION
previous fix with disabling cache made browser to ignore etag headers at all, so we enable it back. just checking that browser cache data will never be used.