### PR TITLE
[fix tests] Tox config updates 

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,9 @@ setenv =
    CPLUS_INCLUDE_PATH=/usr/include/gdal
    C_INCLUDE_PATH=/usr/include/gdal
 
-whitelist_externals = pipenv
+allowlist_externals =
+        pipenv
+        sh
 
 commands =
         pip install "setuptools<58.0"


### PR DESCRIPTION
Updates tox whitelist_externals - deprecated from v4.0.0 to allowlist_externals