### PR TITLE
[ch33349] Email url broken - it doubles up on the host since intervention function also returns a url with the host

### DIFF
--- a/src/etools/applications/partners/models.py
+++ b/src/etools/applications/partners/models.py
@@ -3270,7 +3270,7 @@ class InterventionReviewNotification(TimeStampedModel):
             'intervention_number': self.review.intervention.reference_number,
             'meeting_date': self.review.meeting_date.strftime('%d-%m-%Y'),
             'user_name': self.user.get_full_name(),
-            'url': '{}{}'.format(settings.HOST, self.review.intervention.get_frontend_object_url(suffix='review'))
+            'url': self.review.intervention.get_frontend_object_url(suffix='review')
         }
 
         send_notification_with_template(


### PR DESCRIPTION
[ch33349] Email url broken - it doubles up on the host since intervention function also returns a url with the host