### PR TITLE
[ch33051] Doesn't count audits as completed having empty date_of_draft_report_to_ip

### DIFF
--- a/src/etools/applications/partners/models.py
+++ b/src/etools/applications/partners/models.py
@@ -882,12 +882,14 @@ class PartnerOrganization(TimeStampedModel):
         from etools.applications.audit.models import Audit, Engagement, SpecialAudit
         audits = Audit.objects.filter(
             partner=self,
-            year_of_audit=datetime.datetime.now().year
+            year_of_audit=datetime.datetime.now().year,
+            date_of_draft_report_to_ip__isnull=False,
         ).exclude(status=Engagement.CANCELLED)
 
         s_audits = SpecialAudit.objects.filter(
             partner=self,
-            year_of_audit=datetime.datetime.now().year
+            year_of_audit=datetime.datetime.now().year,
+            date_of_draft_report_to_ip__isnull=False,
         ).exclude(status=Engagement.CANCELLED)
         return audits, s_audits
 

--- a/src/etools/applications/partners/tests/test_models.py
+++ b/src/etools/applications/partners/tests/test_models.py
@@ -594,7 +594,7 @@ class TestPartnerOrganizationModel(BaseTenantTestCase):
             date_of_draft_report_to_ip=datetime.datetime(datetime.datetime.today().year, 8, 1)
         )
         self.partner_organization.update_audits_completed()
-        self.assertEqual(self.partner_organization.hact_values['audits']['completed'], 3)
+        self.assertEqual(self.partner_organization.hact_values['audits']['completed'], 2)
 
     def test_partner_organization_get_admin_url(self):
         "Test that get_admin_url produces the URL we expect."


### PR DESCRIPTION
comment in #3473