### PR TITLE
[ch35574] Sentry issues

### DIFF
--- a/src/etools/applications/audit/admin.py
+++ b/src/etools/applications/audit/admin.py
@@ -30,7 +30,7 @@ class EngagementAdmin(RestrictedEditAdmin):
     list_filter = [
         'status', 'start_date', 'end_date', 'status', 'engagement_type',
     ]
-    search_fields = 'partner__organization__name', 'agreement__auditor_firm__name',
+    search_fields = 'partner__organization__name', 'agreement__auditor_firm__organization__name',
     filter_horizontal = ('authorized_officers', 'active_pd', 'staff_members', 'users_notified', 'sections', 'offices')
     raw_id_fields = ('po_item', 'partner', 'active_pd', 'staff_members', 'authorized_officers', 'users_notified', )
 

--- a/src/etools/applications/partners/permissions.py
+++ b/src/etools/applications/partners/permissions.py
@@ -435,7 +435,7 @@ class ListCreateAPIMixedPermission(permissions.BasePermission):
                     return True
             return False
         elif request.method == 'POST':
-            # user must have have admin access
+            # user must have admin access
             return request.user.is_authenticated and request.user.is_staff
         else:
             # This class shouldn't see methods other than GET and POST, but regardless the answer is 'no you may not'.

--- a/src/etools/applications/partners/tests/test_api_interventions.py
+++ b/src/etools/applications/partners/tests/test_api_interventions.py
@@ -1991,7 +1991,7 @@ class BaseInterventionReportingRequirementMixin:
             init_count + 2
         )
 
-    def test_post_invalid_no_report_type(self):
+    def test_post_invalid_no_start_date(self):
         """Missing report type value"""
         report_type = ReportingRequirement.TYPE_QPR
         requirement_qs = ReportingRequirement.objects.filter(
@@ -2016,6 +2016,35 @@ class BaseInterventionReportingRequirementMixin:
             response.data,
             {"reporting_requirements": [
                 {"start_date": ["This field is required."]}
+            ]}
+        )
+
+    def test_post_invalid_null_start_date(self):
+        """Missing report type value"""
+        report_type = ReportingRequirement.TYPE_QPR
+        requirement_qs = ReportingRequirement.objects.filter(
+            intervention=self.intervention,
+            report_type=report_type,
+        )
+        init_count = requirement_qs.count()
+        response = self.forced_auth_req(
+            "post",
+            self._get_url(report_type),
+            user=self.unicef_staff,
+            data={
+                "reporting_requirements": [{
+                    "start_date": None,
+                    "end_date": datetime.date(2001, 3, 31),
+                    "due_date": datetime.date(2001, 4, 15),
+                }]
+            }
+        )
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(requirement_qs.count(), init_count)
+        self.assertEqual(
+            response.data,
+            {"reporting_requirements": [
+                {"start_date": ["This field may not be null."]}
             ]}
         )
 

--- a/src/etools/applications/partners/views/v2.py
+++ b/src/etools/applications/partners/views/v2.py
@@ -119,7 +119,7 @@ class PMPStaticDropdownsListAPIView(APIView):
 
 
 class PMPDropdownsListApiView(APIView):
-    permission_classes = (IsAdminUser,)
+    permission_classes = (IsAuthenticated, IsAdminUser)
 
     def get(self, request):
         """
@@ -158,7 +158,7 @@ class PMPDropdownsListApiView(APIView):
 
 
 class PartnershipDashboardAPIView(APIView):
-    permission_classes = (IsAdminUser,)
+    permission_classes = (IsAuthenticated, IsAdminUser)
 
     def get(self, request, ct_pk=None, office_pk=None):
         """

--- a/src/etools/applications/reports/serializers/v2.py
+++ b/src/etools/applications/reports/serializers/v2.py
@@ -425,6 +425,8 @@ class RAMIndicatorSerializer(serializers.ModelSerializer):
 
 class ReportingRequirementSerializer(serializers.ModelSerializer):
     id = serializers.IntegerField(required=False)
+    start_date = serializers.DateField(required=True, allow_null=False)
+    end_date = serializers.DateField(required=True, allow_null=False)
 
     class Meta:
         model = ReportingRequirement

--- a/src/etools/applications/reports/views/v3.py
+++ b/src/etools/applications/reports/views/v3.py
@@ -110,7 +110,7 @@ class PMPSpecialReportingRequirementRetrieveUpdateDestroyView(
 
 
 class PMPResultFrameworkView(PMPBaseViewMixin, ResultFrameworkView):
-    permission_classes = [UserIsStaffPermission | UserIsPartnerStaffMemberPermission]
+    permission_classes = [IsAuthenticated, UserIsStaffPermission | UserIsPartnerStaffMemberPermission]
 
     def get_queryset(self, format=None):
         qs = InterventionResultLink.objects.filter(

--- a/src/etools/applications/users/views.py
+++ b/src/etools/applications/users/views.py
@@ -108,8 +108,9 @@ class ChangeUserRoleView(CreateAPIView, GenericAPIView):
             user.profile.country_override = None
             details["country_override"] = "The user's country override has been removed"
         if user.profile.country != workspace:
-            details["country"] = "The user has been moved from {} to {}".format(user.profile.country.name,
-                                                                                workspace.name)
+            details["country"] = "The user has been moved from {} to {}"\
+                .format(user.profile.country.name if user.profile.country else 'N/A',
+                        workspace.name)
         user.profile.country = workspace
         user.profile.save()
         details["current_roles"] = list(user.groups.filter().values_list("name", flat=True))


### PR DESCRIPTION
[ch35574]
includes fixes for:

https://excubo.unicef.io/sentry/etools-prod/issues/15971/ /api/pmp/v3/interventions/766/reporting-requirements/HR/ start_date is required and cannot be null
https://excubo.unicef.io/sentry/etools-prod/issues/41471/ /admin/audit/spotcheck/ Related Field got invalid lookup: name
https://excubo.unicef.io/sentry/etools-prod/issues/41478/ /api/reports/v3/interventions/results/{pk}/  'AnonymousUser' object has no attribute 'get_partner' 
https://excubo.unicef.io/sentry/etools-prod/issues/33915/  'NoneType' object has no attribute 'name' - user has no country on profile