### PR TITLE
[ch35657] User Management API: IntegrityError: duplicate key value violates unique constraint "unique_realm"

### DIFF
--- a/src/etools/applications/users/views.py
+++ b/src/etools/applications/users/views.py
@@ -99,7 +99,7 @@ class ChangeUserRoleView(CreateAPIView, GenericAPIView):
                     country=workspace,
                     organization=unicef_organization,
                     group=role,
-                    is_active=True
+                    defaults={"is_active": True}
                 )[0])
             if data["access_type"] == "set":
                 user.realms.exclude(id__in=[realm.id for realm in realms]).update(is_active=False)


### PR DESCRIPTION
[ch35657]
fix for user management API https://excubo.unicef.io/sentry/etools-prod/issues/41532/