### PR TITLE
[ch37587]Add new field on the response API to be able to translate

### DIFF
--- a/src/etools/applications/last_mile/serializers.py
+++ b/src/etools/applications/last_mile/serializers.py
@@ -57,7 +57,7 @@ class MaterialSerializer(serializers.ModelSerializer):
     class Meta:
         model = models.Material
         exclude = ('partner_materials',)
-    
+
     def get_material_type_translate(self, obj):
         material_type_translate = "RUTF" if obj.number in settings.RUTF_MATERIALS else "Other"
         return material_type_translate
@@ -111,7 +111,6 @@ class MaterialDetailSerializer(serializers.ModelSerializer):
     items = MaterialItemsSerializer(many=True)
     description = serializers.CharField(read_only=True)
     material_type_translate = serializers.SerializerMethodField()
-
 
     class Meta:
         model = models.Material

--- a/src/etools/applications/last_mile/serializers.py
+++ b/src/etools/applications/last_mile/serializers.py
@@ -52,9 +52,15 @@ class PointOfInterestLightSerializer(serializers.ModelSerializer):
 
 
 class MaterialSerializer(serializers.ModelSerializer):
+    material_type_translate = serializers.SerializerMethodField()
+
     class Meta:
         model = models.Material
         exclude = ('partner_materials',)
+    
+    def get_material_type_translate(self, obj):
+        material_type_translate = "RUTF" if obj.number in settings.RUTF_MATERIALS else "Other"
+        return material_type_translate
 
 
 class TransferListSerializer(serializers.ModelSerializer):
@@ -90,27 +96,43 @@ class TransferMinimalSerializer(serializers.ModelSerializer):
 
 class MaterialItemsSerializer(serializers.ModelSerializer):
     transfer = TransferMinimalSerializer()
+    material_type_translate = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Item
         exclude = ('material', 'transfers_history', 'created', 'modified',)
 
+    def get_material_type_translate(self, obj):
+        material_type_translate = "RUTF" if obj.material.number in settings.RUTF_MATERIALS else "Other"
+        return material_type_translate
+
 
 class MaterialDetailSerializer(serializers.ModelSerializer):
     items = MaterialItemsSerializer(many=True)
     description = serializers.CharField(read_only=True)
+    material_type_translate = serializers.SerializerMethodField()
+
 
     class Meta:
         model = models.Material
         exclude = ["partner_materials"]
+
+    def get_material_type_translate(self, obj):
+        material_type_translate = "RUTF" if obj.number in settings.RUTF_MATERIALS else "Other"
+        return material_type_translate
 
 
 class MaterialListSerializer(serializers.ModelSerializer):
     description = serializers.CharField(read_only=True)
+    material_type_translate = serializers.SerializerMethodField()
 
     class Meta:
         model = models.Material
         exclude = ["partner_materials"]
+
+    def get_material_type_translate(self, obj):
+        material_type_translate = "RUTF" if obj.number in settings.RUTF_MATERIALS else "Other"
+        return material_type_translate
 
 
 class ItemSerializer(serializers.ModelSerializer):

--- a/src/etools/applications/last_mile/tests/test_views.py
+++ b/src/etools/applications/last_mile/tests/test_views.py
@@ -257,6 +257,7 @@ class TestTransferView(BaseTenantTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.incoming.refresh_from_db()
         self.assertEqual(self.incoming.status, models.Transfer.COMPLETED)
+        self.assertEqual("RUTF", response.data['items'][0]['material']['material_type_translate'])
         self.assertIn(self.attachment.filename, response.data['proof_file'])
         self.assertEqual(self.incoming.name, checkin_data['name'])
         self.assertEqual(self.incoming.items.count(), len(response.data['items']))
@@ -292,6 +293,7 @@ class TestTransferView(BaseTenantTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.incoming.refresh_from_db()
         self.assertEqual(self.incoming.status, models.Transfer.COMPLETED)
+        self.assertEqual("RUTF", response.data['items'][0]['material']['material_type_translate'])
         self.assertIn(response.data['proof_file'], self.attachment.file.path)
 
         self.assertIn(f'DW @ {checkin_data["destination_check_in_at"].strftime("%y-%m-%d")}', self.incoming.name)
@@ -333,6 +335,7 @@ class TestTransferView(BaseTenantTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.incoming.refresh_from_db()
         self.assertEqual(self.incoming.status, models.Transfer.COMPLETED)
+        self.assertEqual("RUTF", response.data['items'][0]['material']['material_type_translate'])
         self.assertIn(response.data['proof_file'], self.attachment.file.path)
         self.assertEqual(self.incoming.name, checkin_data['name'])
         self.assertEqual(self.incoming.items.count(), len(response.data['items']))
@@ -381,6 +384,7 @@ class TestTransferView(BaseTenantTestCase):
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.incoming.refresh_from_db()
         self.assertEqual(self.incoming.status, models.Transfer.COMPLETED)
+        self.assertEqual("RUTF", response.data['items'][0]['material']['material_type_translate'])
         self.assertIn(response.data['proof_file'], self.attachment.file.path)
         self.assertEqual(self.incoming.name, checkin_data['name'])
         self.assertEqual(self.incoming.items.count(), len(response.data['items']))
@@ -478,6 +482,7 @@ class TestTransferView(BaseTenantTestCase):
         url = reverse('last_mile:transfers-new-check-out', args=(self.warehouse.pk,))
         response = self.forced_auth_req('post', url, user=self.partner_staff, data=checkout_data)
 
+        self.assertEqual("Other", response.data['items'][0]['material']['material_type_translate'])
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], models.Transfer.PENDING)
         self.assertEqual(response.data['transfer_type'], models.Transfer.DISTRIBUTION)
@@ -515,6 +520,7 @@ class TestTransferView(BaseTenantTestCase):
         url = reverse('last_mile:transfers-new-check-out', args=(self.warehouse.pk,))
         response = self.forced_auth_req('post', url, user=self.partner_staff, data=checkout_data)
 
+        self.assertEqual("Other", response.data['items'][0]['material']['material_type_translate'])
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], models.Transfer.COMPLETED)
         self.assertEqual(response.data['transfer_type'], models.Transfer.WASTAGE)
@@ -549,6 +555,7 @@ class TestTransferView(BaseTenantTestCase):
         url = reverse('last_mile:transfers-new-check-out', args=(self.warehouse.pk,))
         response = self.forced_auth_req('post', url, user=self.partner_staff, data=checkout_data)
 
+        self.assertEqual("Other", response.data['items'][0]['material']['material_type_translate'])
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], models.Transfer.COMPLETED)
         self.assertEqual(response.data['transfer_type'], models.Transfer.DISPENSE)
@@ -584,6 +591,7 @@ class TestTransferView(BaseTenantTestCase):
         url = reverse('last_mile:transfers-new-check-out', args=(self.warehouse.pk,))
         response = self.forced_auth_req('post', url, user=self.partner_staff, data=checkout_data)
 
+        self.assertEqual("Other", response.data['items'][0]['material']['material_type_translate'])
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.data['status'], models.Transfer.PENDING)
         self.assertEqual(response.data['transfer_type'], models.Transfer.HANDOVER)


### PR DESCRIPTION
As discussed with Tiaan this morning, I added the new field on the endpoint to be able to make difference between RUTF materials on the FE based on the backend configuration.