### PR TITLE
Updating circle_ci config: avoid test reruns on PR merges

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 
 parameters:
   base-tag:
@@ -33,6 +33,15 @@ jobs:
                 echo "Not a followed branch not pushing latest"
               fi
             fi
+      - run:
+          name: Triggering test workflow
+          command: |
+            BASE_TAG="$(md5sum pdm.lock | cut -c1-6)$(md5sum Dockerfile-base | cut -c1-6)"
+            curl --user ${CIRCLE_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=test \
+                --data build_parameters[BASE_TAG]=${BASE_TAG} \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
   test:
     working_directory: ~/code
     # The primary container is an instance of the first list image listed. Your build commands run in this container.

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 parameters:
   base-tag:
@@ -33,15 +33,6 @@ jobs:
                 echo "Not a followed branch not pushing latest"
               fi
             fi
-      - run:
-          name: Triggering test workflow
-          command: |
-            BASE_TAG="$(md5sum pdm.lock | cut -c1-6)$(md5sum Dockerfile-base | cut -c1-6)"
-            curl --user ${CIRCLE_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=test \
-                --data build_parameters[BASE_TAG]=${BASE_TAG} \
-                --data revision=$CIRCLE_SHA1 \
-                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
   test:
     working_directory: ~/code
     # The primary container is an instance of the first list image listed. Your build commands run in this container.
@@ -72,17 +63,6 @@ jobs:
           key: deps2-{{ .Branch }}--{{ checksum "pdm.lock" }}-{{ checksum ".circleci/config.yml" }}
           paths:
             - ".tox/d42/"
-      - run:
-          name: Triggering build_and_deploy job
-          command: |
-            if (echo "$DEPLOY_BRANCHES" | grep -q "$CIRCLE_BRANCH"); then
-              curl --user ${CIRCLE_TOKEN}: \
-                --data build_parameters[CIRCLE_JOB]=build_and_upload \
-                --data revision=$CIRCLE_SHA1 \
-                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
-            else
-              echo "not triggered - '$CIRCLE_BRANCH' is not a deployable branch: '$DEPLOY_BRANCHES'"
-            fi
 
   build_and_upload:
     machine: true
@@ -113,15 +93,28 @@ jobs:
             else
               echo "Not a followed branch not pushing latest"
             fi
-      - run:
-          name: trigger redeploy?
-          command: |
-            pip install requests
-            python utils/trigger_redeploy.py --loglevel=INFO
-
 
 workflows:
-  version: 2
-  tests_start:
+  version: 2.1
+
+  #Run tests on all PRs always but not on merges.
+  run-tests-on-pr:
+    when:
+      equal: [ true, << pipeline.git.pull_request >> ]
     jobs:
       - setup
+      - test
+
+  # Build only on merges to develop, staging and master. Don't run the tests here.
+  deploy-on-merge:
+    when:
+      not:
+        equal: [ true, << pipeline.git.pull_request >> ]
+    jobs:
+      - build_and_upload:
+          filters:
+            branches:
+              only:
+                - develop
+                - staging
+                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -114,7 +114,9 @@ workflows:
   run-tests-on-pr:
     jobs:
       - setup
-      - test
+      - test:
+          requires:
+            - setup
 
   # Build only on merges to develop, staging and master. Don't run the tests here.
   deploy-on-merge:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2.1
+version: 2
 
 parameters:
   base-tag:
@@ -8,8 +8,8 @@ parameters:
 
 jobs:
   setup:
-    machine: true
-    docker_layer_caching: true
+    machine:
+      docker_layer_caching: true
     steps:
       - checkout
       - run:
@@ -33,6 +33,15 @@ jobs:
                 echo "Not a followed branch not pushing latest"
               fi
             fi
+      - run:
+          name: Triggering test workflow
+          command: |
+            BASE_TAG="$(md5sum pdm.lock | cut -c1-6)$(md5sum Dockerfile-base | cut -c1-6)"
+            curl --user ${CIRCLE_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=test \
+                --data build_parameters[BASE_TAG]=${BASE_TAG} \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
   test:
     working_directory: ~/code
     # The primary container is an instance of the first list image listed. Your build commands run in this container.
@@ -63,6 +72,17 @@ jobs:
           key: deps2-{{ .Branch }}--{{ checksum "pdm.lock" }}-{{ checksum ".circleci/config.yml" }}
           paths:
             - ".tox/d42/"
+      - run:
+          name: Triggering build_and_deploy job
+          command: |
+            if (echo "$DEPLOY_BRANCHES" | grep -q "$CIRCLE_BRANCH"); then
+              curl --user ${CIRCLE_TOKEN}: \
+                --data build_parameters[CIRCLE_JOB]=build_and_upload \
+                --data revision=$CIRCLE_SHA1 \
+                https://circleci.com/api/v1.1/project/github/$CIRCLE_PROJECT_USERNAME/$CIRCLE_PROJECT_REPONAME/tree/$CIRCLE_BRANCH
+            else
+              echo "not triggered - '$CIRCLE_BRANCH' is not a deployable branch: '$DEPLOY_BRANCHES'"
+            fi
 
   build_and_upload:
     machine: true
@@ -93,28 +113,15 @@ jobs:
             else
               echo "Not a followed branch not pushing latest"
             fi
+      - run:
+          name: trigger redeploy?
+          command: |
+            pip install requests
+            python utils/trigger_redeploy.py --loglevel=INFO
+
 
 workflows:
-  version: 2.1
-
-  #Run tests on all PRs always but not on merges.
-  run-tests-on-pr:
-    when:
-      equal: [ true, << pipeline.git.pull_request >> ]
+  version: 2
+  tests_start:
     jobs:
       - setup
-      - test
-
-  # Build only on merges to develop, staging and master. Don't run the tests here.
-  deploy-on-merge:
-    when:
-      not:
-        equal: [ true, << pipeline.git.pull_request >> ]
-    jobs:
-      - build_and_upload:
-          filters:
-            branches:
-              only:
-                - develop
-                - staging
-                - master

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,8 +56,12 @@ jobs:
       - run:
           name: Run Tests
           command: |
-            pip install tox
-            /etools/__pypackages__/3.12/bin/tox -e d42
+            if [ ! -z "$CIRCLE_PULL_REQUEST" ]; then  #Only run tests on PRs
+              pip install tox
+              /etools/__pypackages__/3.12/bin/tox -e d42
+            else
+              echo "Not a pull request. Skipping test job trigger."
+            fi
           no_output_timeout: 30m
       - save_cache:
           key: deps2-{{ .Branch }}--{{ checksum "pdm.lock" }}-{{ checksum ".circleci/config.yml" }}
@@ -71,27 +75,36 @@ jobs:
       - run:
           name: Building the image
           command: |
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            BASE_TAG="$(md5sum pdm.lock | cut -c1-6)$(md5sum Dockerfile-base | cut -c1-6)"
-            TAG=${CIRCLE_BRANCH}
-            (docker pull unicef/etools-base:${BASE_TAG}) ||
-            (docker build -t unicef/etools-base:${BASE_TAG} -f Dockerfile-base . && docker push unicef/etools-base:${BASE_TAG})
-            docker build --build-arg BASE_TAG=${BASE_TAG} -t unicef/etools:$TAG .
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then  #Only run if it's a push, not a PR
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              BASE_TAG="$(md5sum pdm.lock | cut -c1-6)$(md5sum Dockerfile-base | cut -c1-6)"
+              TAG=${CIRCLE_BRANCH}
+              (docker pull unicef/etools-base:${BASE_TAG}) ||
+              (docker build -t unicef/etools-base:${BASE_TAG} -f Dockerfile-base . && docker push unicef/etools-base:${BASE_TAG})
+              docker build --build-arg BASE_TAG=${BASE_TAG} -t unicef/etools:$TAG .
+            else
+              echo "PR detected. Skipping build_and_upload job."
+            fi
       - run:
           name: Pushing to Docker Hub
           command: |
-            TAG=${CIRCLE_BRANCH}
-            BASE_TAG="$(md5sum pdm.lock | cut -c1-6)$(md5sum Dockerfile-base | cut -c1-6)"
-            docker login -u $DOCKER_USER -p $DOCKER_PASS
-            docker push unicef/etools:$TAG
-            if (echo "develop" | grep -q "$CIRCLE_BRANCH"); then
-              docker tag unicef/etools-base:${BASE_TAG} unicef/etools-base:latestet
-              docker push unicef/etools-base:latestet
-            elif (echo "master" | grep -q "$CIRCLE_BRANCH"); then
-              docker tag unicef/etools-base:${BASE_TAG} unicef/etools-base:latest_prodet
-              docker push unicef/etools-base:latest_prodet
+            if [ -z "$CIRCLE_PULL_REQUEST" ]; then  #Only run if it's a push, not a PR
+
+              TAG=${CIRCLE_BRANCH}
+              BASE_TAG="$(md5sum pdm.lock | cut -c1-6)$(md5sum Dockerfile-base | cut -c1-6)"
+              docker login -u $DOCKER_USER -p $DOCKER_PASS
+              docker push unicef/etools:$TAG
+              if (echo "develop" | grep -q "$CIRCLE_BRANCH"); then
+                docker tag unicef/etools-base:${BASE_TAG} unicef/etools-base:latestet
+                docker push unicef/etools-base:latestet
+              elif (echo "master" | grep -q "$CIRCLE_BRANCH"); then
+                docker tag unicef/etools-base:${BASE_TAG} unicef/etools-base:latest_prodet
+                docker push unicef/etools-base:latest_prodet
+              else
+                echo "Not a followed branch not pushing latest"
+              fi
             else
-              echo "Not a followed branch not pushing latest"
+              echo "PR detected. Skipping build_and_upload job."
             fi
 
 workflows:
@@ -99,17 +112,12 @@ workflows:
 
   #Run tests on all PRs always but not on merges.
   run-tests-on-pr:
-    when:
-      equal: [ true, << pipeline.git.pull_request >> ]
     jobs:
       - setup
       - test
 
   # Build only on merges to develop, staging and master. Don't run the tests here.
   deploy-on-merge:
-    when:
-      not:
-        equal: [ true, << pipeline.git.pull_request >> ]
     jobs:
       - build_and_upload:
           filters:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,4 +1,4 @@
-version: 2
+version: 2.1
 
 parameters:
   base-tag:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -36,6 +36,7 @@ jobs:
       - run:
           name: Triggering test workflow
           command: |
+            # Launch the test job from here, it needs the BASE_TAG value to pull the docker image
             BASE_TAG="$(md5sum pdm.lock | cut -c1-6)$(md5sum Dockerfile-base | cut -c1-6)"
             curl --user ${CIRCLE_TOKEN}: \
                 --data build_parameters[CIRCLE_JOB]=test \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -123,9 +123,6 @@ workflows:
   run-tests-on-pr:
     jobs:
       - setup
-      - test:
-          requires:
-            - setup
 
   # Build only on merges to develop, staging and master. Don't run the tests here.
   deploy-on-merge:


### PR DESCRIPTION
Objective:
- Only run tests on PRs, not on pushes to branches (even PR merges)
- Pushes (PR merges) should only build and push for develop, staging and master branches.

Changes:
- Updated config to circle_ci v2.1
- Split setup, test, execution into 2 workflows: one for PRs, one for pushes and merges.
- Remove launch of build_and_push job from the test job. Not needed anymore as they're split workflows now.