### PR TITLE
added cache invalidation fo bulk deactivation

### DIFF
--- a/src/etools/applications/locations/services.py
+++ b/src/etools/applications/locations/services.py
@@ -1,9 +1,13 @@
 from dataclasses import dataclass
 
+from django.db import connection
 from django.db.models import QuerySet
+
+from unicef_locations.cache import invalidate_cache
 
 from etools.applications.core.models import BulkDeactivationLog
 from etools.applications.locations.models import Location
+from etools.libraries.views.cache import invalidate_view_cache
 
 
 @dataclass
@@ -25,4 +29,8 @@ class LocationsDeactivationService:
                 model_name="Location",
                 app_label="locations",
             )
+            try:
+                invalidate_cache()
+            finally:
+                invalidate_view_cache('locations.{}'.format(connection.tenant.country_short_code or ''))
         return DeactivateLocationsResult(deactivated_count=updated)


### PR DESCRIPTION
Root cause: 
- bulk deactivation uses a queryset update, which skips Django signals. 
- Our location endpoints are aggressively cached with ETag + page cache. 
- Because signals didn’t fire, caches weren’t invalidated, so the frontend kept seeing stale data with is_active=True.

Additional Note : 

update_location_cache_on_save isn't triggered when we bulk deactivate, because we're doing a bulk update via QuerySet.update(is_active=False). In Django, update() bypasses Model.save() and therefore does not trigger pre_save/post_save signals. Only instance-level .save() triggers those signals.